### PR TITLE
Trying to add Hinting to Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,35 @@ HALp is a 24 hour TA for the course, that helps students understand why their te
 
 If a test fails and:
 
--  is an example, HALp lets users know that the example is invalid.
--  is a general `test expect``, HALp offers no help.
--  is an assertion, HALp leverages the structure of implications to generate a mutation of the `wheat` that reflects the misconception embodied in the failing assertion. 
-   -  This is then run against an auto-grader, whose results are used to generate feedback.
+### Is an example, 
+
+We are able to add hinting for examples that directly reference a wheat predicate (or its negation). We default to basic feedback (valid vs invalid) in all other cases.
+
+1. We first generate a characteristic predicate for the wheat failing example (`e`). We do this by first separating the example into bounds imposed on (ie explicit assignments on) sigs, bounds imposed on relations (ie explicit assignments on relations), and expressions.  We then construct a characteristic predicate `s` as follows:
+
+	- Each sig assignment of the form `X = X1 + X2` is converted to an existentially quantified expression : `some disj X1, X2 : X | `. 
+	- All relational and expression-based assignments are placed inside these existential quantifiers.
+
+2. We then modify the wheat `i` to a new predicate `i'` reflecting student belief as follows:
+   - If `e` is a positive example, `i'` represents an easing of `i`. That is: `i' = {i OR s}`.
+   - If `e` is a negative example, `i'` represents a constriction of `i`. That is: `i' = {i AND !s}`
+
+We replace `i` with `i'` in the wheat, which is then run against an auto-grader, whose results are used to generate feedback.
+
+### Is an assertion
+
+We leverage the structure of implications to generate a mutation of the `wheat` that reflects the misconception embodied in the failing assertion.
+Assertions are bound to 2 forms:
+
+1. Student believes their predicate (`s`) implies an instructor predicate (`i`). We create a mutation of `i`, `i' =  { i or s }`
+
+2. Student believes an instructor predicate (`i`) implies their predicate (`s`). We create a mutation of `i`, `i' =  { i and s }`
+
+We replace `i` with `i'` in the wheat, which is then run against an auto-grader, whose results are used to generate feedback.
+
+### Is a general `test expect`
+We offer no help
+
 
 In doing so, HALp does not focus on every potential mismatch between the `wheat` and the student's tests. Rather, it focuses on those deemed important by the instructor (as reflected in the autograder), and uses those to generate feedback.
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -31,17 +31,15 @@ async function getUserId(context) {
 	
 	try
 	{
-		var uid = await  context.secrets.get(UID_KEY);
-		return uid.toString();
+		var uid = await context.secrets.get(UID_KEY).toString();
 	}
 	catch {
 		uid = uuidv4().toString();
 		await context.secrets.store(UID_KEY, uid);
 	}
-	forgeOutput.appendLine(`You anonymous ID is ${uid}`);
+	forgeOutput.appendLine(`Your anonymous ID is ${uid}.`);
 	return uid;
 }
-
 
 let racket: RacketProcess = new RacketProcess(forgeEvalDiagnostics, forgeOutput);
 
@@ -58,8 +56,6 @@ function subscribeToDocumentChanges(context: vscode.ExtensionContext, myDiagnost
 }
 
 // TODO: Want to make this an extension method on TextDocument, but cannot wrangle it.
-
-
 function textDocumentToLog(d, focusedDoc) {
 	const content = d.getText();
 	const filePath = d.isUntitled ? "untitled" : d.fileName;
@@ -139,8 +135,6 @@ export async function activate(context: ExtensionContext) {
 		const editor = vscode.window.activeTextEditor;
 		const fileURI = editor.document.uri;
 		const filepath = fileURI.fsPath;
-
-
 		const runId = uuidv4();
 
 		forgeOutput.clear();
@@ -170,7 +164,6 @@ export async function activate(context: ExtensionContext) {
 			log['runId'] = runId;
 
 			logger.log_payload(log, LogLevel.ERROR, Event.FORGE_RUN);
-
 			console.error('Cannot spawn Forge process');
 		}
 
@@ -192,10 +185,6 @@ export async function activate(context: ExtensionContext) {
 		});
 
 		racketProcess.on('exit', (code: string) => {
-			
-
-
-			// This isn't showing anything.
 			if (!racket.racketKilledManually) {
 				if (myStderr !== '') {
 					this.sendEvalErrors(myStderr, fileURI, this.evalDiagnostics);

--- a/client/src/forge-utilities.ts
+++ b/client/src/forge-utilities.ts
@@ -308,6 +308,18 @@ export function exampleToPred(example, sigNames: string[], wheatPredNames : stri
     const exampleBody = example.exampleBody;
 
 	
+	// We can do negative examples here as well.
+	//TODO:
+	/*
+		Generate the predicate for the example.
+		Modify the wheat to be 
+
+		i' {
+			i and (not s)	
+		}
+
+		Will take some munging, but can be done.
+	*/
 
 
 	if (!wheatPredNames.includes(examplePredicate)) {

--- a/client/src/forge-utilities.ts
+++ b/client/src/forge-utilities.ts
@@ -184,6 +184,20 @@ export function getSigList(s : string) : string[] {
 	return sigNames;
 }
 
+// TODO: What about predicates that have [] in them?
+export function getPredList(fileContent: string): string[] {
+	const predicateRegex = /pred\s+(\w+)(\s|\{|\[)/g;
+	const predicates: string[] = [];
+	let match;
+
+	while ((match = predicateRegex.exec(fileContent)) !== null) {
+		const predicateName = match[1];
+		predicates.push(predicateName);
+	}
+
+	return predicates;
+}
+
 
 /*
 example diagonalPasses is {some brd: Board | winningDiag[brd, X] } for {
@@ -202,7 +216,7 @@ export function findAllExamples(fileContent : string) {
     let match;
     let examples = [];
 
-    while ((match = exampleRegex.exec(fileContent)) !== null) {
+    while ((match = exampleRegex.exec(fileContent)) != null) {
         const exampleName = match[1];
         const examplePredicate = match[2].trim();
         const exampleBody = match[3].trim();
@@ -216,6 +230,29 @@ export function findAllExamples(fileContent : string) {
 
     return examples;
 }
+
+
+// Write a function to find a specific example
+// Finds a specific example by name
+export function findExampleByName(fileContent : string, exampleName: string) {
+	
+	const exampleRegex = new RegExp(`example\\s+${exampleName}\\s+is\\s+(?:{)?([\\s\\S]*?)(?:})?\\s+for\\s+{([\\s\\S]*)}`);
+	const match = exampleRegex.exec(fileContent);
+
+	if (match == null) {
+		return null;
+	}
+
+	const examplePredicate = match[1].trim();
+	const exampleBody = match[2].trim();
+
+	return {
+		exampleName,
+		examplePredicate,
+		exampleBody
+	};
+}
+
 
 // Converts an example to a predicate reflecting the characteristics of the example.
 export function exampleToPred(example, sigNames: string[], wheatPredNames : string[] ) : string {
@@ -308,23 +345,4 @@ export function exampleToPred(example, sigNames: string[], wheatPredNames : stri
 		`;
 
 	return exampleAsPred;
-
-	// Now we have sufficiency: sigExpressions => examplePredicate 
-
-	// Now, how do we translate this to intent/ wheat
-
-	
-	return "";
-	}
-
-	// (what do we do for negative examples that have failed the wheat? Well, the hint is clear : this *is* an instance.)
-	
-	// Now we have sufficiency: p_bounds => p 
-
-	// Now, how do we translate this to intent/ wheat
-
-
-
-
-	return "";
 }

--- a/client/src/halp.ts
+++ b/client/src/halp.ts
@@ -83,7 +83,8 @@ export class HalpRunner {
 
 		// TODO: Remove [abcdef-...].rkt from w_o.
 
-		const assertionsBetter = "\n\u{2139} In general, I am able to provide more feedback around assertions than examples.";
+		const assertionsBetter = `\n\u{2139} I am sorry I could not provide more feedback here. 
+		I am better at providing more detailed feedback when analyzing assertions than examples.`;
 
 		const defaultFeedback = `I found a runtime or syntax error in your tests:
 ${w_o}`;
@@ -96,30 +97,12 @@ ${w_o}`;
 
 			try {
 				var hint = await this.tryGetHintFromExample(testName, testFileName, w, studentTests, w_o);
-				if (hint != "") {
+				if (hint != "")
+				{
 					return `${testName} is not consistent with the problem specification. ` + hint;
 				}
-	
-				const payload = {
-	
-					"studentTests": studentTests,
-					"wheat_output" : w_o,
-					"testFile" : testFileName
-				}
-				this.logger.log_payload(payload, LogLevel.INFO, Event.AMBIGUOUS_TEST);
-	
-				// Else, return this feedback around no hint found.
-				return `"${testName}" examines behaviors that are either ambiguous or not clearly defined in the problem specification.
-	This test is not necessarily incorrect, but I cannot provide feedback around it. 
-	If you want feedback around other tests you have written, you will have to temporarily comment out this test and run me again.
-	
-	If you disagree with this assessment, and believe that this test does deal with behavior explicitly described in the problem specification,
-	please fill out this form: ${formurl}`;
-
-
 			}
 			catch (e) {
-				console.log(e);
 			}
 
 			return w_o + assertionsBetter;

--- a/client/src/halp.ts
+++ b/client/src/halp.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { 
 	assertion_regex, example_regex, test_regex, adjustWheatToStudentMisunderstanding, getPredicatesOnly, BothPredsStudentError ,
-	findAllExamples, exampleToPred, getSigList
+	findAllExamples, exampleToPred, getSigList, getPredList, findExampleByName
 
 
 } from './forge-utilities'; 
@@ -335,11 +335,13 @@ please fill out this form: ${formurl}`;
 	// w_o : wheat output
 	private async tryGetHintFromExample(testName : string, testFileName: string, w : string, studentTests : string, w_o : string) : Promise<string> {
 
-		const matchingExamples = findAllExamples(studentTests).filter(example => example.exampleName === testName);
-		const failedExample = matchingExamples[0];
+		// const matchingExamples = findAllExamples(studentTests).filter(example => example.exampleName == testName);
+		// const failedExample = matchingExamples[0];
+
+		const failedExample = findExampleByName(studentTests, testName);
 
 		const sigNames = getSigList(w);
-		const wheatPredNames = [];
+		const wheatPredNames = getPredList(w);
 
 		const exampleAsPred = exampleToPred(failedExample, sigNames, wheatPredNames);
 		const student_preds = getPredicatesOnly(studentTests) + "\n" + exampleAsPred + "\n";

--- a/client/src/halp.ts
+++ b/client/src/halp.ts
@@ -55,20 +55,6 @@ export class HalpRunner {
 			return `Your tests are all consistent with the assignment specification.
 			However, it's important to remember that this doesn't automatically mean the tests are exhaustive or explore every aspect of the problem.`;
 			
-			/*
-				This is where we could (would?) add some sort of metric around thoroughness.
-
-				1. We could check coverage of their tests against the wheat (somehow). 
-					Cons: We don't care about the parts of the wheat that are not super important to the problem.
-				
-				2. We could straight up *count* the number of tests. Is every predicate in the solution covered?
-					-- This seems overly constrictive, we would also have to identify (somehow) every exported predicate in
-					the wheat.
-				
-
-			*/
-
-
 			// TODO: Can we add some sort of thoroughness metric?
 			/*This means that all of your tests are passing, 
 			 but you may want to add more tests to ensure your code explores more aspects of the problem.`;
@@ -76,12 +62,8 @@ export class HalpRunner {
 		}
 
 
-
-
 		const formurl = "https://forms.gle/t2imxLGNC7Yqpo6GA"
 		const testName = this.getFailingTestName(w_o);
-
-		// TODO: Remove [abcdef-...].rkt from w_o.
 
 		const assertionsBetter = `\n\u{2139} I am sorry I could not provide more feedback here. 
 		I am better at providing more detailed feedback when analyzing assertions than examples.`;
@@ -149,8 +131,6 @@ please fill out this form: ${formurl}`;
 			If you want feedback around other tests you have written, you will have to temporarily comment out this test and run me again.`;
 		}
 		
-
-
 		return defaultFeedback;
 	}
 
@@ -299,9 +279,6 @@ please fill out this form: ${formurl}`;
 	private async tryGetHintFromAssertion(testFileName: string, w : string, student_preds : string, w_o : string) : Promise<string> {
 
 		let w_wrapped = adjustWheatToStudentMisunderstanding(testFileName, w, student_preds, w_o);
-		// We should log all the conceptual mutants we generate!!
-		// LOG w_wrapped
-
 		const payload = {
 			"testFileName": testFileName,
 			"assignment": testFileName.replace('.test.frg', ''),
@@ -318,10 +295,6 @@ please fill out this form: ${formurl}`;
 		return await this.get_hint_from_autograder_output(ag_output, testFileName);
 	}
 
-
-
-
-
 	
 	// TODO: Does not play nice with parameterized predicates.
 	private async tryGetHintFromExample(testName : string, testFileName: string, w : string, studentTests : string, w_o : string) : Promise<string> {
@@ -332,10 +305,6 @@ please fill out this form: ${formurl}`;
 
 		const sigNames = getSigList(w);
 		const wheatPredNames = getPredList(w);
-
-
-		
-
 
 		const exampleAsPred = exampleToPred(failedExample, sigNames, wheatPredNames);
 		const student_preds = getPredicatesOnly(studentTests) + "\n" + exampleAsPred + "\n";

--- a/client/src/halp.ts
+++ b/client/src/halp.ts
@@ -95,6 +95,9 @@ ${w_o}`;
 		
 		if (example_regex.test(w_o)) {
 
+			// Fundamentally the issue is that the characteristic predicate from a 
+			// positive example gives us such a *specific* modification to a predicate,
+			// that it is rare for us to offer meaningful feedback.
 			try {
 				var hint = await this.tryGetHintFromExample(testName, testFileName, w, studentTests, w_o);
 				if (hint != "")

--- a/client/src/racketprocess.ts
+++ b/client/src/racketprocess.ts
@@ -31,7 +31,7 @@ export class RacketProcess {
 		this.kill(false);
 		this.childProcess = spawn('racket', [`"${filePath}"`], { shell: true });
 
-		// This is broken. Need to understand and fix.
+
 		this.childProcess.on('exit', (code: string) => {
 			this.racketKilledManually = false;
 		});


### PR DESCRIPTION
Adding hinting for examples that directly reference a wheat predicate (or its negation).


1. We first generate a characteristic predicate for the wheat failing example (`e`). We do this by first separating the example into bounds imposed on (ie explicit assignments on) sigs, bounds imposed on relations (ie explicit assignments on relations), and expressions.  We then construct a characteristic predicate `s` as follows:

	- Each sig assignment of the form `X = X1 + X2` is converted to an existentially quantified expression : `some disj X1, X2 : X | `. 
	- All relational and expression-based assignments are placed inside these existential quantifiers.

2. We then modify the wheat `i` to a new predicate `i'` reflecting student belief as follows:
   - If `e` is a positive example, `i'` represents an easing of `i`. That is: `i' = {i OR s}`.
   - If `e` is a negative example, `i'` represents a constriction of `i`. That is: `i' = {i AND !s}`


## Issues:
This strategy *may* be too specific to actually generate hints since they generate mutations adding pointwise permissiveness (or restrictiveness) to the wheat predicate. 
- This involves a lot of regex munging, since we are functioning outside the forge language. This means that there may be cases where our predicate generation fails.  We default to basic feedback (valid vs invalid) in these cases. We do *not* let students know if an example is in the general modelling space because of this. Rather, we revert to the validity feedback generated by direct comparison to the wheat.
- As with assertion-level hint generation, we do not have a good strategy to deal with tests on parameterized predicates. 
