### PR TITLE
Bug fixes around user facing output

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -186,20 +186,20 @@ export async function activate(context: ExtensionContext) {
 
 		racketProcess.on('exit', (code: string) => {
 			if (!racket.racketKilledManually) {
-				if (myStderr !== '') {
-					this.sendEvalErrors(myStderr, fileURI, this.evalDiagnostics);
-					this.userFacingOutput.appendLine(myStderr);
+				if (myStderr != '') {
+					racket.sendEvalErrors(myStderr, fileURI, this.evalDiagnostics);
+					racket.userFacingOutput.appendLine(myStderr);
 				} else {
-					this.showFileWithOpts(filepath, null, null);
-					this.userFacingOutput.appendLine('Finished running.');
+					racket.showFileWithOpts(filepath, null, null);
+					racket.userFacingOutput.appendLine('Finished running.');
 				}
 			} else {
-				this.showFileWithOpts(filepath, null, null);
-				this.userFacingOutput.appendLine('Forge process terminated.');
+				racket.showFileWithOpts(filepath, null, null);
+				racket.userFacingOutput.appendLine('Forge process terminated.');
 			}
 
 			var payload = {
-				"output" : this.userFacingOutput.getText(),
+				"output-errors" : myStderr,
 				"runId" : runId 
 			}
 			logger.log_payload(payload, LogLevel.INFO, Event.FORGE_RUN_RESULT);

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -187,8 +187,8 @@ export async function activate(context: ExtensionContext) {
 		racketProcess.on('exit', (code: string) => {
 			if (!racket.racketKilledManually) {
 				if (myStderr != '') {
-					racket.sendEvalErrors(myStderr, fileURI, this.evalDiagnostics);
-					racket.userFacingOutput.appendLine(myStderr);
+					racket.sendEvalErrors(myStderr, fileURI, forgeEvalDiagnostics);
+					//racket.userFacingOutput.appendLine(myStderr);
 				} else {
 					racket.showFileWithOpts(filepath, null, null);
 					racket.userFacingOutput.appendLine('Finished running.');
@@ -198,6 +198,7 @@ export async function activate(context: ExtensionContext) {
 				racket.userFacingOutput.appendLine('Forge process terminated.');
 			}
 
+			// Output *may* have user file path in it. Do we want this?
 			var payload = {
 				"output-errors" : myStderr,
 				"runId" : runId 

--- a/client/src/racketprocess.ts
+++ b/client/src/racketprocess.ts
@@ -7,7 +7,7 @@ export class RacketProcess {
 		
 	private childProcess: ChildProcess | null;
 	public racketKilledManually : boolean;
-	private userFacingOutput : vscode.OutputChannel;
+	public userFacingOutput : vscode.OutputChannel;
 	private evalDiagnostics : vscode.DiagnosticCollection;
 	
 
@@ -21,6 +21,7 @@ export class RacketProcess {
 
 
 	runFile(filePath : string) : ChildProcess | null {
+
 		// always auto-save before any run
 		if (!vscode.window.activeTextEditor.document.save())
 		{
@@ -29,12 +30,13 @@ export class RacketProcess {
 		}
 
 		this.kill(false);
+		this.racketKilledManually = false;
+
 		this.childProcess = spawn('racket', [`"${filePath}"`], { shell: true });
 
-
-		this.childProcess.on('exit', (code: string) => {
-			this.racketKilledManually = false;
-		});
+		// this.childProcess.on('exit', (code: string) => {
+		// 	//this.racketKilledManually = false;
+		// });
 		return this.childProcess
 	}
 


### PR DESCRIPTION
Introduced bugs when porting racket into its own process. Had to step this back a bit, unfortunately. Some weird state management now, but state should be good across concurrent runs.