### PR TITLE
Fixing logging error

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -188,7 +188,6 @@ export async function activate(context: ExtensionContext) {
 			if (!racket.racketKilledManually) {
 				if (myStderr != '') {
 					racket.sendEvalErrors(myStderr, fileURI, forgeEvalDiagnostics);
-					//racket.userFacingOutput.appendLine(myStderr);
 				} else {
 					racket.showFileWithOpts(filepath, null, null);
 					racket.userFacingOutput.appendLine('Finished running.');

--- a/client/src/racketprocess.ts
+++ b/client/src/racketprocess.ts
@@ -72,9 +72,9 @@ export class RacketProcess {
 			}
 		}
 
+		this.userFacingOutput.appendLine(text);
 		if (matcher) {
-			this.userFacingOutput.appendLine(text);
-
+			
 			const line = parseInt(matcher[2]) - 1;
 			const col = parseInt(matcher[3]) - 1;
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"description": "Forge Language Server",
 	"author": "",
 	"license": "",
-	"version": "2.0.3",
+	"version": "2.1.1",
 	"repository": {
 		"type": "git",
 		"url": ""


### PR DESCRIPTION
Extension only showed error output that matched a particular regex to students (that is, when location etc were determined and the error was in terms of the Forge file). Relaxing this to show all Forge errors, with localization and highlighting IF possible