### PR TITLE
Adding Thoroughness feedback to Toadus Ponens

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,7 +32,8 @@
 				"--extensionTestsPath=${workspaceRoot}/client/out/test/index",
 				"${workspaceRoot}/client/testFixture"
 			],
-			"outFiles": ["${workspaceRoot}/client/out/test/**/*.js"]
+			"outFiles": ["${workspaceRoot}/client/out/test/**/*.js"],
+			// Remove the "target" property
 		}
 	],
 	"compounds": [

--- a/client/src/forge-utilities.ts
+++ b/client/src/forge-utilities.ts
@@ -68,7 +68,7 @@ function findForgePredicates(inputText : string) : [string] {
     return predicates;
 }
 
-
+// TODO: This is buggy!
 export function findForgeExamples(inputText) {
     const withoutComments = removeForgeComments(inputText);
     const lines = withoutComments.split('\n');
@@ -136,7 +136,10 @@ export function getPredList(fileContent: string): string[] {
 
 export function findAllExamples(fileContent : string) {
 	// TODO: A language server would help us not have to write these long (possibly buggy) regexes.
-	const exampleRegex = /example\s+(\w+)\s+is\s+(?:{)?(.*?)(?:})?\s+for\s+{([\s\S]*)}/g;
+
+	// TODO:THis is buggy. Perhaps we can make sure that the word example does not show up inside this?
+	// Think of other ways to parse an example.
+	const exampleRegex = /example\s+(\w+)\s+is\s+(?:{)?(.*?)(?:})?\s+for\s+{([\s\S]*?)}/g;
  
 
 	let examples = [];
@@ -158,7 +161,6 @@ export function findAllExamples(fileContent : string) {
 
 export function findAllAssertions(fileContent : string) {
 	const assertRegex = /assert\s+(\w+)\s+is\s+(necessary|sufficient)\s+for\s+(\w+)/g;
-
 
     let assertions = [];
 	let matches = fileContent.matchAll(assertRegex);
@@ -451,6 +453,8 @@ export function extractTestSuite(input: string): ExtractedTestSuite[] {
 
 
 		const indices : Object[] = [];
+
+		// TODO: This *SHOULD* bottom out
 		if (input.length == 0 || input == null) {
 			return indices;
 		}
@@ -460,8 +464,8 @@ export function extractTestSuite(input: string): ExtractedTestSuite[] {
 
 
 
-
-		let suiteEnd = 0;
+		// 1 , so that in the worst case we move forward only slightly
+		let suiteEnd = 1;
 		// This only catches the first one.
 		// Now there is a second one.
 
@@ -494,7 +498,15 @@ export function extractTestSuite(input: string): ExtractedTestSuite[] {
 			}
 		}
 		const remaining = input.substring(suiteEnd);
-		const next = findTestSuiteIndices(remaining)
+		console.log(remaining);
+
+
+
+
+		return indices;
+		// Needs to be in test suite fors, well formed. But I think somethign is wrong
+		// TODO: Issue here? If it doesn't match, it'll start spinning
+		const next = findTestSuiteIndices(remaining);
 		return indices.concat(next);
 	}
 	  

--- a/client/src/forge-utilities.ts
+++ b/client/src/forge-utilities.ts
@@ -431,12 +431,16 @@ export function findAllStructuredTests(suite: string) {
 	return {examples, assertions, quantifiedAssertions};
 }
   
+
+// TODO: THis is not quite correct! It's not finding the test suites.
 export function extractTestSuite(input: string): ExtractedTestSuite[] {
+	
+	
 	const pattern = /test suite for\s+(.*?)\s*\{(.*?)\}/gs;
-	let match;
+	let matches = input.matchAll(pattern);
 	const results: ExtractedTestSuite[] = [];
   
-	while ((match = pattern.exec(input)) !== null) {
+	for (const match of matches) {
 	  const [fullMatch, predicateName, content] = match;
 	  if (isBalancedBraces(content)) {
 

--- a/client/src/forge-utilities.ts
+++ b/client/src/forge-utilities.ts
@@ -137,8 +137,6 @@ export function getPredList(fileContent: string): string[] {
 export function findAllExamples(fileContent : string) {
 	// TODO: A language server would help us not have to write these long (possibly buggy) regexes.
 
-	// TODO:THis is buggy. Perhaps we can make sure that the word example does not show up inside this?
-	// Think of other ways to parse an example.
 	const exampleRegex = /example\s+(\w+)\s+is\s+(?:{)?(.*?)(?:})?\s+for\s+{([\s\S]*?)}/g;
  
 
@@ -183,8 +181,11 @@ export function findAllAssertions(fileContent : string) {
 
 
 export function findAllQuantifiedAssertions(fileContent : string) {
-	// TODO: Fix!! This regex is not working.
-	const quantifiedAssertRegex = /assert\s+all([\s\S]+?)\|\s*(\w+)\s+is\s+(necessary|sufficient)\s+for\s+(\w+)/gs;
+
+	// TODO: BUGYY REGEX
+	// ex: Needn't be word characters
+	// not sure how to end assertion match. Need not be []
+	const quantifiedAssertRegex = /assert\s+(all\s+[\s\S]+?\|)\s*(.+?)\s+is\s+(necessary|sufficient)\s+for\s+(\w+|[^]]+])/gs;
 
 	if (fileContent == null || fileContent == "") {
 		return [];
@@ -196,14 +197,14 @@ export function findAllQuantifiedAssertions(fileContent : string) {
 
     for (const match of matches){
         
+		
 		const quantifiedVars = match[1].trim();
         const lhs = match[2].trim();
 		const op = match[3].trim();
         const rhs = match[4].trim();
 
-
 		const assertionName = `Assert All ${lhs} is ${op} for ${rhs}`;
-
+		
         assertions.push({
             assertionName,
 			quantifiedVars,
@@ -224,10 +225,11 @@ export function findExampleByName(fileContent : string, exampleName: string) {
 	// HACK: We first isolate examples and then parse the correct one because I was
 	// having trouble with the regex. A language server would help.
 	const all_examples = findForgeExamples(fileContent);
-	const r = new RegExp(`\\b${exampleName}\\b`);
+	const r = new RegExp(`\\b${exampleName}\\b`, 'g'); // Add 'g' flag for global search
 	var to_search = all_examples.filter(e => r.test(e))[0];
 
-	const exampleRegex = new RegExp(`example\\s+${exampleName}\\s+is\\s+(?:{)?([\\s\\S]*?)(?:})?\\s+for\\s+{([\\s\\S]*)}`);
+
+	const exampleRegex = new RegExp(`example\\s+${exampleName}\\s+is\\s+(?:{)?([\\s\\S]*?)(?:})?\\s+for\\s+{([\\s\\S]*?)}`, 'g'); // Add 'g' flag for global search
 	const match = exampleRegex.exec(to_search);
 
 	if (match == null) {

--- a/client/src/halp.ts
+++ b/client/src/halp.ts
@@ -82,16 +82,18 @@ export class HalpRunner {
 
 		if (this.isConsistent(w_o)) {
 		
-			this.forgeOutput.appendLine(`Your tests are all consistent with the assignment specification.
-			However, it's important to remember that this doesn't automatically mean the tests are exhaustive or explore every aspect of the problem.`);
-			this.forgeOutput.appendLine(`🐸 Step 2: Trying to generate feedback around the thoroughness of the tests in your 'test-suite's.
-			My feedback is limited to assertions and examples that directly reference the problem specification.`);
+			this.forgeOutput.appendLine(`🎉 Your tests are all consistent with the assignment specification! 🎉
+			Just because your tests are consistent does not mean they thoroughly explore the problem space.`);
+			this.forgeOutput.appendLine(`🐸 Step 2: JTrying to generate a hint around the thoroughness of your test-suite .
+			This feedback ignores any tests that are not assertions or examples that directly reference the problem specification.`);
 
 			mutator.mutateToStudentUnderstanding();
+
 			let x = await this.tryGetThoroughnessFromMutant(testFileName, mutator.mutant, mutator.student_preds);
 			if (x.length == 0) {
-				return ["I could not generate further feedback. It's important to remember that this doesn't automatically mean the tests are exhaustive or explore every aspect of the problem."]
+				return ["I could not generate a hint. It's important to remember that this doesn't automatically mean the tests are exhaustive or explore every aspect of the problem."]
 			}
+			return x;
 		}
 
 
@@ -304,7 +306,7 @@ please fill out this form: ${formurl}`];
 
 		const autograderTests = await this.getAutograderTests(testFileName);
 		const ag_output = await this.runTestsAgainstModel(autograderTests, mutant);	
-		return await this.tryGetHintsFromAutograderOutput(ag_output, testFileName);
+		return await this.tryGetThoroughnessFromAutograderOutput(ag_output, testFileName);
 	}
 
 }

--- a/client/src/halp.ts
+++ b/client/src/halp.ts
@@ -88,7 +88,10 @@ export class HalpRunner {
 			My feedback is limited to assertions and examples that directly reference the problem specification.`);
 
 			mutator.mutateToStudentUnderstanding();
-			return this.tryGetThoroughnessFromMutant(testFileName, mutator.mutant, mutator.student_preds);
+			let x = await this.tryGetThoroughnessFromMutant(testFileName, mutator.mutant, mutator.student_preds);
+			if (x.length == 0) {
+				return ["I could not generate further feedback. It's important to remember that this doesn't automatically mean the tests are exhaustive or explore every aspect of the problem."]
+			}
 		}
 
 

--- a/client/src/halp.ts
+++ b/client/src/halp.ts
@@ -75,6 +75,7 @@ export class HalpRunner {
 		
 
 		this.forgeOutput.appendLine('🐸 Step 1: Analyzing your tests...');
+		
 
 		const  w_o = await this.runTestsAgainstModel(studentTests, w);
 		const source_text = combineTestsWithModel(w, studentTests);
@@ -87,9 +88,15 @@ export class HalpRunner {
 			this.forgeOutput.appendLine(`🐸 Step 2: JTrying to generate a hint around the thoroughness of your test-suite .
 			This feedback ignores any tests that are not assertions or examples that directly reference the problem specification.`);
 
+			// Flush the output
+			this.forgeOutput.show(); 
+
 			mutator.mutateToStudentUnderstanding();
+			let skipped_tests = mutator.error_messages.join("\n");
+			this.forgeOutput.appendLine(skipped_tests);
 
 			let x = await this.tryGetThoroughnessFromMutant(testFileName, mutator.mutant, mutator.student_preds);
+
 			if (x.length == 0) {
 				return ["I could not generate a hint. It's important to remember that this doesn't automatically mean the tests are exhaustive or explore every aspect of the problem."]
 			}

--- a/client/src/halp.ts
+++ b/client/src/halp.ts
@@ -82,9 +82,10 @@ export class HalpRunner {
 
 		if (this.isConsistent(w_o)) {
 		
-			this.forgeOutput.appendLine(`🐸 Step 2: Your tests are all consistent with the assignment specification.
+			this.forgeOutput.appendLine(`Your tests are all consistent with the assignment specification.
 			However, it's important to remember that this doesn't automatically mean the tests are exhaustive or explore every aspect of the problem.`);
-
+			this.forgeOutput.appendLine(`🐸 Step 2: Trying to generate feedback around the thoroughness of the tests in your 'test-suite's.
+			My feedback is limited to assertions and examples that directly reference the problem specification.`);
 
 			mutator.mutateToStudentUnderstanding();
 			return this.tryGetThoroughnessFromMutant(testFileName, mutator.mutant, mutator.student_preds);

--- a/client/src/logger.ts
+++ b/client/src/logger.ts
@@ -16,6 +16,7 @@ export enum LogLevel {
 export enum Event {
     ASSISTANCE_REQUEST = "assistance_request",
     CONCEPTUAL_MUTANT = "conceptual_mutant",
+    THOROUGHNESS_MUTANT = "thoroughness_mutant",
     HALP_RESULT = "halp_result",
     FORGE_RUN_RESULT = "forge_run_result",
     FORGE_RUN = "forge_run",
@@ -63,7 +64,8 @@ export class Logger {
         let p = this.payload(payload, loglevel, event);
         let log = doc(this.log_target);
         try {
-           await setDoc(log, p);
+            // TODO: Uncomment
+           // await setDoc(log, p);
         } catch (error) {
             console.error("Log failure ", error);
         }

--- a/client/src/mutator.ts
+++ b/client/src/mutator.ts
@@ -1,5 +1,5 @@
-import { example_regex, assertion_regex, quantified_assertion_regex, extractTestSuite , assertionToExpr} from './forge-utilities';
-import { getPredicatesOnly, removeForgeComments, exampleToPred, getSigList, getPredList, findExampleByName , test_regex, getFailingTestName} from './forge-utilities';
+import { example_regex, assertion_regex, quantified_assertion_regex, extractTestSuite, assertionToExpr } from './forge-utilities';
+import { getPredicatesOnly, removeForgeComments, exampleToPred, getSigList, getPredList, findExampleByName, test_regex, getFailingTestName } from './forge-utilities';
 
 /*
 	ISSUES:
@@ -16,7 +16,6 @@ function extractSubstring(text: string, startRow: number, startColumn: number, s
 	// 1 index to 0 index
 	startRow -= 1;
 
-	//TODO: Forge output has span incorrect
 	span += 1;
 
 	// Split the text into rows
@@ -48,16 +47,16 @@ export class Mutator {
 	forge_output: string;
 	test_file_name: string;
 	mutant: string;
-	source_text : string;
+	source_text: string;
 
-	error_messages : string[];
+	error_messages: string[];
 
-	inconsistent_tests : string[];
+	inconsistent_tests: string[];
 
 
-	num_mutations : number = 0;
+	num_mutations: number = 0;
 
-	constructor(wheat: string, student_tests: string, forge_output: string, test_file_name: string, source_text : string) {
+	constructor(wheat: string, student_tests: string, forge_output: string, test_file_name: string, source_text: string) {
 		this.wheat = wheat;
 
 		this.student_tests = removeForgeComments(student_tests);
@@ -101,8 +100,6 @@ export class Mutator {
 
 		const target_regexp = new RegExp("\\b" + i + "\\b", 'g');
 
-
-		// TODO: FIX: IS THIS CORRECT?
 		let w_wrapped = w.replace(target_regexp, i_inner);
 		let exp_to_constrain = s.replace(target_regexp, i_inner);
 		let added_pred =
@@ -129,8 +126,15 @@ export class Mutator {
 	}
 
 	isInstructorAuthored(pred: string): boolean {
+		if (pred.includes('[')) {
+			pred = pred.substring(0, pred.indexOf('['));
+		}
+		pred = pred.trim();
+
 		var exp = `pred\\s+${pred}\\b`
+
 		var x = new RegExp(exp).test(this.wheat);
+
 		return x;
 	}
 
@@ -144,14 +148,14 @@ export class Mutator {
 			pred = isNegation[2];
 		}
 		return {
-			predIsInstructorAuthored : this.isInstructorAuthored(pred),
-			isNegation : isNegation != null,
+			predIsInstructorAuthored: this.isInstructorAuthored(pred),
+			isNegation: isNegation != null,
 			pred: pred
-		} 
+		}
 	}
 
 
-	mutateToAssertion(test_name : string, lhs_pred: string, rhs_pred: string, op: string, quantified_prefix: string = "") : void {
+	mutateToAssertion(test_name: string, lhs_pred: string, rhs_pred: string, op: string, quantified_prefix: string = ""): void {
 
 
 		const isLhsInstructorAuthored = this.isInstructorAuthored(lhs_pred);
@@ -170,7 +174,7 @@ export class Mutator {
 			return;
 		}
 
-		
+
 		// If the student believes that i => s,
 		// then they believe that if i then s. So constrain i to be { i AND s }
 		if (isLhsInstructorAuthored) {
@@ -207,7 +211,7 @@ export class Mutator {
 	// failed_example needs to be an object, as returned by findExampleByName.
 	mutateToExample(failed_example) {
 
-		// TODO!! Should these be called on the wheat or the mutant?
+
 		const sigNames = getSigList(this.wheat);
 		const wheatPredNames = getPredList(this.wheat);
 
@@ -238,21 +242,21 @@ export class Mutator {
 			: this.easePredicate(mutant_with_example, failed_example.examplePredicate, failed_example.exampleName);
 	}
 
-// TODO: This does not error  loudly!
-	mutateToStudentMisunderstanding()  {
+	// TODO: This does not error  loudly!
+	mutateToStudentMisunderstanding() {
 
 		let w_os = this.forge_output.split("\n");
-		for (let w_o of w_os) {	
+		for (let w_o of w_os) {
 			const testName = getFailingTestName(w_o);
 
-			if (example_regex.test(w_o)) {				
+			if (example_regex.test(w_o)) {
 				// Fundamentally the issue is that the characteristic predicate from a 
 				// positive example gives us such a *specific* modification to a predicate,
 				// that it is rare for us to offer meaningful feedback.
-				
+
 				const failedExample = findExampleByName(this.student_tests, testName);
 				this.mutateToExample(failedExample);
-				
+
 			} else if (quantified_assertion_regex.test(w_o)) {
 
 
@@ -273,12 +277,12 @@ export class Mutator {
 				const lhs_instantiation = failing_test.match(lhs_match)[1].trim();
 				const rhs_match = /\bfor\b(.*?)(\bfor\b|$)/;
 				const rhs_instantiation = failing_test.match(rhs_match)[1].trim();
-				
+
 				this.mutateToAssertion(testName, lhs_instantiation, rhs_instantiation, op, quantifier);
 
 
-	
-			}else if (assertion_regex.test(w_o)) {
+
+			} else if (assertion_regex.test(w_o)) {
 
 
 				// mutate to assertion
@@ -292,7 +296,7 @@ export class Mutator {
 			else if (test_regex.test(w_o)) {
 
 				const test_expect_failure_msg = `Excluding test "${testName}" from my analysis. I cannot provide feedback around test-expects.`;
-				this.error_messages.push(test_expect_failure_msg)	
+				this.error_messages.push(test_expect_failure_msg)
 			}
 			else if (testName != "") {
 				throw new Error("Something went very wrong!");
@@ -303,20 +307,20 @@ export class Mutator {
 	}
 
 
-	xor (a: boolean, b: boolean): boolean  {
+	xor(a: boolean, b: boolean): boolean {
 		return (a && !b) || (!a && b);
 	};
 
 
 	mutateToStudentUnderstanding() {
 
-		
-/*
-    - For each test-suite, identify the predicate being tested.
-	- For each test in the suite.
-		- Produce a predicate that characterizes the test.
-		- Exclude these predicates from the predicate under test.
-*/
+
+		/*
+			- For each test-suite, identify the predicate being tested.
+			- For each test in the suite.
+				- Produce a predicate that characterizes the test.
+				- Exclude these predicates from the predicate under test.
+		*/
 
 		// Mutant already has all student predicates in it.
 
@@ -328,19 +332,19 @@ export class Mutator {
 		extractTestSuite(this.student_tests).forEach((test_suite) => {
 
 
-			const predicate_under_test = test_suite.predicateName;	
+			const predicate_under_test = test_suite.predicateName;
 			const examples = test_suite.tests.examples;
 			const assertions = test_suite.tests.assertions;
 			const quantified_assertions = test_suite.tests.quantifiedAssertions;
 
 			// For each of these, filter out examples around which we cannot give feedback.
-			
+
 			// Now for each example, modify predicates.
 			examples.forEach((example) => {
 
-				
+
 				const pred_info = this.checkTargetPredicate(example['examplePredicate']);
-				if(pred_info.predIsInstructorAuthored) {
+				if (pred_info.predIsInstructorAuthored) {
 					// Ensure the types match up
 					// I *think* this is right?
 
@@ -353,9 +357,9 @@ export class Mutator {
 
 
 					let p = exampleToPred(example, getSigList(this.wheat), getPredList(this.wheat));
-	
+
 					predicates_to_add_to_mutation.push(p);
-					expressions_in_mutation.push({ "name" : example['exampleName'], "expression" : example['exampleName'], predicate_under_test: example['examplePredicate'], isNegativeTest : pred_info.isNegation	});
+					expressions_in_mutation.push({ "name": example['exampleName'], "expression": example['exampleName'], predicate_under_test: example['examplePredicate'], isNegativeTest: pred_info.isNegation });
 				}
 				else {
 					this.error_messages.push(`Excluding ${example['exampleName']} from analysis. I can only give feedback around examples that directly reference one predicate from the assignment statement.`);
@@ -368,25 +372,36 @@ export class Mutator {
 
 			// For each assertion, modify predicates.
 			assertions.forEach((assertion) => {
-				if(this.xor(this.isInstructorAuthored(assertion['lhs']),
-				 	   this.isInstructorAuthored(assertion['rhs']))) {
-					
-						// Create the appropriate predicate.
-						// ie create the characteristic predicate of the example.				
-						let e = assertionToExpr(assertion['lhs'], assertion['rhs'], assertion['op']);
-						expressions_in_mutation.push({ "name" : assertion['assertionName'], "expression" : e, predicate_under_test	});
-						
+				if (this.xor(this.isInstructorAuthored(assertion['lhs']),
+					this.isInstructorAuthored(assertion['rhs']))) {
+
+					// Create the appropriate predicate.
+					// ie create the characteristic predicate of the example.				
+					let e = assertionToExpr(assertion['lhs'], assertion['rhs'], assertion['op']);
+					expressions_in_mutation.push({ "name": assertion['assertionName'], "expression": e, predicate_under_test });
+
+				}
+				else {
+					this.error_messages.push(`Excluding ${assertion['assertionName']} from analysis. I can only give feedback around assertions that directly reference at exactly one predicate from the assignment statement.`);
 				}
 			});
 
 			// For each quantified assertion, modify predicates.
 			quantified_assertions.forEach((qassertion) => {
-				if(this.xor(this.isInstructorAuthored(qassertion['lhsPredicate']),
-				 	   this.isInstructorAuthored(qassertion['rhsPredicate']))) {
-					
-						// Create the appropriate predicate (ie create the characteristic predicate of the example.)
-						let e = assertionToExpr(qassertion['lhs'], qassertion['rhs'], qassertion['op'], qassertion['quantifiedVars']);
-						expressions_in_mutation.push({ "name" : qassertion['assertionName'], "expression" : e, predicate_under_test	});
+
+
+				// This is where we need to check if the predicate is instructor authored.
+				const lhs = this.isInstructorAuthored(qassertion['lhs']);
+				const rhs = this.isInstructorAuthored(qassertion['rhs']);
+
+				if (this.xor(lhs, rhs)) {
+
+					// Create the appropriate predicate (ie create the characteristic predicate of the example.)
+					let e = assertionToExpr(qassertion['lhs'], qassertion['rhs'], qassertion['op'], qassertion['quantifiedVars']);
+					expressions_in_mutation.push({ "name": qassertion['assertionName'], "expression": e, predicate_under_test });
+				}
+				else {
+					this.error_messages.push(`Excluding ${qassertion['assertionName']} from analysis. I can only give feedback around assertions that directly reference at exactly one predicate from the assignment statement.`);
 				}
 			});
 		});
@@ -394,22 +409,16 @@ export class Mutator {
 		// Now add all the predicates to the current mutation.
 		var added_preds = predicates_to_add_to_mutation.join("\n");
 		this.mutant += added_preds;
-		
+
 		for (let e of expressions_in_mutation) {
-			
+
 			if (e.hasOwnProperty('isNegativeTest') && e['isNegativeTest']) {
-				// I think we easy the predicate here right?
-				// TODO: Think about this.
 				this.mutant = this.easePredicate(this.mutant, e['predicate_under_test'], e['expression']);
 			} else {
-				// TODO: This works for positive examples and implications, but NOT negative examples.
 				this.mutant = this.constrainPredicateByExclusion(this.mutant, e['predicate_under_test'], e['expression']);
 			}
 		}
 	}
 
 }
-
-
-
 

--- a/client/src/mutator.ts
+++ b/client/src/mutator.ts
@@ -353,7 +353,7 @@ export class Mutator {
 
 
 
-					let p = exampleToPred(example, getSigList(this.wheat), getPredList(this.student_tests));
+					let p = exampleToPred(example, getSigList(this.wheat), getPredList(this.wheat));
 	
 					predicates_to_add_to_mutation.push(p);
 					expressions_in_mutation.push({ "name" : example['exampleName'], "expression" : example['exampleName'], predicate_under_test: example['examplePredicate'], isNegativeTest : pred_info.isNegation	});

--- a/client/src/mutator.ts
+++ b/client/src/mutator.ts
@@ -1,4 +1,3 @@
-import { get } from 'http';
 import { example_regex, assertion_regex, quantified_assertion_regex, extractTestSuite , assertionToExpr} from './forge-utilities';
 import { getPredicatesOnly, removeForgeComments, exampleToPred, getSigList, getPredList, findExampleByName , test_regex, getFailingTestName} from './forge-utilities';
 
@@ -339,7 +338,7 @@ export class Mutator {
 			// Now for each example, modify predicates.
 			examples.forEach((example) => {
 
-
+				
 				const pred_info = this.checkTargetPredicate(example['examplePredicate']);
 				if(pred_info.predIsInstructorAuthored) {
 					// Ensure the types match up
@@ -396,9 +395,8 @@ export class Mutator {
 		var added_preds = predicates_to_add_to_mutation.join("\n");
 		this.mutant += added_preds;
 		
-		// I think this is it
 		for (let e of expressions_in_mutation) {
-
+			
 			if (e.hasOwnProperty('isNegativeTest') && e['isNegativeTest']) {
 				// I think we easy the predicate here right?
 				// TODO: Think about this.
@@ -407,10 +405,6 @@ export class Mutator {
 				// TODO: This works for positive examples and implications, but NOT negative examples.
 				this.mutant = this.constrainPredicateByExclusion(this.mutant, e['predicate_under_test'], e['expression']);
 			}
-
-
-			
-			
 		}
 	}
 

--- a/client/src/test/mutator.tests.ts
+++ b/client/src/test/mutator.tests.ts
@@ -6,7 +6,7 @@ import { removeForgeComments } from '../forge-utilities';
 import { strict as assert, strictEqual } from 'assert';
 
 // TODO: This is duplicated, find a better place to put it.
-export function combineTestsWithModel(wheatText: string, tests: string) : string {
+export function combineTestsWithModel(wheatText: string, tests: string): string {
 	// todo: What if separator doesn't exist (in that case, look for #lang forge)
 	const TEST_SEPARATOR = "//// Do not edit anything above this line ////"
 	const hashlang_decl = "#lang";
@@ -80,10 +80,6 @@ describe('Mutator', () => {
 
 		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
 		mutator.mutateToStudentMisunderstanding();
-
-		//assert strictEqual(mutator.error_messages[0], )
-
-
 		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(DIRTREE_INFO.wheat));
 	});
 
@@ -143,13 +139,13 @@ describe('Mutator', () => {
 
 		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
 		mutator.mutateToStudentMisunderstanding();
-	  	assert.strictEqual(mutator.num_mutations, 0);
+		assert.strictEqual(mutator.num_mutations, 0);
 
-	   let outputs = mutator.error_messages;
+		let outputs = mutator.error_messages;
 
-	   for (let output of outputs) {
+		for (let output of outputs) {
 			assert.strict(output.includes('someexamplename1') || output.includes('someexamplename'));
-	   }
+		}
 
 	});
 
@@ -192,7 +188,7 @@ describe('Mutator', () => {
 		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
 		let num_mutations = mutator.mutateToStudentMisunderstanding();
 
-		
+
 
 		const expectedMutant = `#lang forge
 
@@ -223,7 +219,7 @@ describe('Mutator', () => {
 				 isDirectedTree_inner2 and mustHaveRoot
 			}`;
 
-			assert.strictEqual(num_mutations, 2);
+		assert.strictEqual(num_mutations, 2);
 		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expectedMutant));
 	});
 
@@ -253,7 +249,7 @@ assert all x : Node | loops is sufficient for isDirectedTree
 		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, truncated_forge_output, DIRTREE_INFO.filename, source_text);
 		let num_mutations = mutator.mutateToStudentMisunderstanding();
 
-		
+
 
 		const expectedMutant = `#lang forge
 
@@ -287,9 +283,9 @@ assert all x : Node | loops is sufficient for isDirectedTree
 
 
 
-		it(' : mutate to Misunderstanding carries out mutations on positive examples.', () => {
-	
-			const tests = `
+	it(' : mutate to Misunderstanding carries out mutations on positive examples.', () => {
+
+		const tests = `
 		  
 			  #lang forge
 	
@@ -302,16 +298,16 @@ assert all x : Node | loops is sufficient for isDirectedTree
 			edges = \`Node1->\`Node2 + \`Node2->\`Node2
 		  }
 		  `;
-			const forge_output = `[directedtree.test.frg:13:0 (span 168)] Invalid example 'lasso'; the instance specified does not satisfy the given predicate. Sterling disabled, so reporting raw instance data:
+		const forge_output = `[directedtree.test.frg:13:0 (span 168)] Invalid example 'lasso'; the instance specified does not satisfy the given predicate. Sterling disabled, so reporting raw instance data:
 			#(struct:Unsat #f ((size-variables 0) (size-clauses 0) (size-primary 0) (time-translation 36) (time-solving 0) (time-building 1708545562033) (time-core 0)) unsat)
 			`;
-			const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-	
-			const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-			mutator.mutateToStudentMisunderstanding();
-	
-		  	const expected_mutant = `
+
+		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+		mutator.mutateToStudentMisunderstanding();
+
+		const expected_mutant = `
 			#lang forge
 			option run_sterling off
 
@@ -335,14 +331,14 @@ assert all x : Node | loops is sufficient for isDirectedTree
 			  pred isDirectedTree { 
 			   isDirectedTree_inner1 or lasso
 			  }`;
-	
-			assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
-		});
+
+		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+	});
 
 
-		it(' : mutate to Misunderstanding carries out mutations on negative examples.', () => {
-	
-			const tests = `
+	it(' : mutate to Misunderstanding carries out mutations on negative examples.', () => {
+
+		const tests = `
 		  
 			  #lang forge
 	
@@ -355,16 +351,16 @@ assert all x : Node | loops is sufficient for isDirectedTree
 			edges = \`Node1->\`Node2 
 		  }
 		  `;
-			const forge_output = `[directedtree.test.frg:13:0 (span 168)] Invalid example 'line'; the instance specified does not satisfy the given predicate. Sterling disabled, so reporting raw instance data:
+		const forge_output = `[directedtree.test.frg:13:0 (span 168)] Invalid example 'line'; the instance specified does not satisfy the given predicate. Sterling disabled, so reporting raw instance data:
 			#(struct:Unsat #f ((size-variables 0) (size-clauses 0) (size-primary 0) (time-translation 36) (time-solving 0) (time-building 1708545562033) (time-core 0)) unsat)
 			`;
-			const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-	
-			const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-			mutator.mutateToStudentMisunderstanding();
-	
-		  	const expected_mutant = `
+
+		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+		mutator.mutateToStudentMisunderstanding();
+
+		const expected_mutant = `
 			#lang forge
 			option run_sterling off
 
@@ -388,13 +384,13 @@ assert all x : Node | loops is sufficient for isDirectedTree
 			  pred isDirectedTree { 
 			   isDirectedTree_inner1 and not line
 			  }`;
-	
-			assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
-		});
 
-		it(' : mutate to Misunderstanding carries out mutations on examples and assertions when combined.', () => {
-	
-			const tests = `
+		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+	});
+
+	it(' : mutate to Misunderstanding carries out mutations on examples and assertions when combined.', () => {
+
+		const tests = `
 		  
 			  #lang forge
 	
@@ -412,20 +408,20 @@ assert all x : Node | loops is sufficient for isDirectedTree
 			edges = \`Node1->\`Node2  + \`Node2->\`Node1
 		  }
 		  `;
-			const forge_output = `[directedtree.test.frg:21:19 (span 50)] Theorem Assertion_mustBeEmpty_is_necessary_for_isDirectedTree failed. Found instance:
+		const forge_output = `[directedtree.test.frg:21:19 (span 50)] Theorem Assertion_mustBeEmpty_is_necessary_for_isDirectedTree failed. Found instance:
 			#(struct:Sat (#hash((Node . ((Node2) (Node3))) (edges . ((Node3 Node2))))) ((size-variables 390) (size-clauses 558) (size-primary 20) (time-translation 77) (time-solving 9) (time-building 1708555673207)) ()) Sterling disabled, so reporting raw instance data:
 			#(struct:Sat (#hash((Node . ((Node2) (Node3))) (edges . ((Node3 Node2))))) ((size-variables 390) (size-clauses 558) (size-primary 20) (time-translation 77) (time-solving 9) (time-building 1708555673207)) ())
 			
 			[directedtree.test.frg:23:18 (span 114)] Invalid example 'loop'; the instance specified does not satisfy the given predicate. Sterling disabled, so reporting raw instance data:
 			#(struct:Unsat #f ((size-variables 0) (size-clauses 0) (size-primary 0) (time-translation 5) (time-solving 0) (time-building 1708555673326) (time-core 0)) unsat)			
 			`;
-			const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
-		
-	
-			const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-			mutator.mutateToStudentMisunderstanding();
-	
-		  	const expected_mutant = `#lang forge
+		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+
+
+		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+		mutator.mutateToStudentMisunderstanding();
+
+		const expected_mutant = `#lang forge
 
 			  option run_sterling off
 			  
@@ -456,30 +452,30 @@ assert all x : Node | loops is sufficient for isDirectedTree
 			  pred isDirectedTree { 
 				  isDirectedTree_inner2 or loop
 			  }`;
-	
-			assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
-		});
+
+		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+	});
 
 
 
 
-		// TODO: MutateToStudentUnderstanding here
+	// TODO: MutateToStudentUnderstanding here
 
 
-		/*
-			Test cases:
-			- [x] Mutate to positive examples ( I suspect multiple examples will be an issue?)
-			- Mutate to negative examples
-			- [x] Mutate to assertions
-			- Mutate to quantified assertions
+	/*
+		Test cases:
+		- [x] Mutate to positive examples ( I suspect multiple examples will be an issue?)
+		- [x] Mutate to negative examples
+		- [x] Mutate to assertions
+		- Mutate to quantified assertions
 
-			- Mutate to example + assertion + quantified assertion
+		- Mutate to example + assertion + quantified assertion
 
-		*/
+	*/
 
-		it(' : mutate to Understanding carries out no mutations if not in test suites.', () => {
+	it(' : mutate to Understanding carries out no mutations if not in test suites.', () => {
 
-			const tests = `
+		const tests = `
 		  
 			  #lang forge
 	
@@ -496,21 +492,21 @@ assert all x : Node | loops is sufficient for isDirectedTree
 					edges = \`Node2->\`Node1 + \`Node2->\`Node3
 				}
 		  `;
-			const forge_output = "";
-			const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
-	
-			const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-			mutator.mutateToStudentUnderstanding();
+		const forge_output = "";
+		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-			const expected_mutant = `#lang forge`
-		
-			assert.strictEqual(mutator.num_mutations, 0);
-		});
-	
+		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+		mutator.mutateToStudentUnderstanding();
 
-		it(' : mutate to Understanding carries mutations on examples.', () => {
+		const expected_mutant = `#lang forge`
 
-			const tests = `
+		assert.strictEqual(mutator.num_mutations, 0);
+	});
+
+
+	it(' : mutate to Understanding carries mutations on examples.', () => {
+
+		const tests = `
 		  
 			  #lang forge
 	
@@ -529,13 +525,13 @@ assert all x : Node | loops is sufficient for isDirectedTree
 				}
 			}
 		  `;
-			const forge_output = "";
-			const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
-	
-			const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-			mutator.mutateToStudentUnderstanding();
+		const forge_output = "";
+		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-			const expected_mutant = `
+		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+		mutator.mutateToStudentUnderstanding();
+
+		const expected_mutant = `
 			#lang forge
 
 			option run_sterling off
@@ -571,15 +567,15 @@ assert all x : Node | loops is sufficient for isDirectedTree
 						isDirectedTree_inner2 and not e2
 			}
 			`;
-			
-			assert.strictEqual(mutator.num_mutations, 2);
-			assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
-		});
+
+		assert.strictEqual(mutator.num_mutations, 2);
+		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+	});
 
 
-		it(' : mutate to Understanding carries mutations on assertions.', () => {
+	it(' : mutate to Understanding carries mutations on assertions.', () => {
 
-			const tests = `
+		const tests = `
 		  
 			  #lang forge
 	
@@ -601,13 +597,13 @@ assert all x : Node | loops is sufficient for isDirectedTree
 				assert a2 is necessary for isDirectedTree
 			}
 		  `;
-			const forge_output = "";
-			const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
-	
-			const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-			mutator.mutateToStudentUnderstanding();
+		const forge_output = "";
+		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-			const expected_mutant = `
+		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+		mutator.mutateToStudentUnderstanding();
+
+		const expected_mutant = `
 			#lang forge
 
 			option run_sterling off
@@ -636,17 +632,17 @@ assert all x : Node | loops is sufficient for isDirectedTree
 			 isDirectedTree_inner2 and not ( isDirectedTree_inner2 => a2)
 	}
 			`;
-			
-			assert.strictEqual(mutator.num_mutations, 2);
-			assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
-		});
+
+		assert.strictEqual(mutator.num_mutations, 2);
+		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+	});
 
 
 
-		// TODO: Negative ex
-		it(' : mutate to Understanding carries out mutations on negative examples.', () => {
-	
-			const tests = `
+	// TODO: Negative ex
+	it(' : mutate to Understanding carries out mutations on negative examples.', () => {
+
+		const tests = `
 		  
 			#lang forge
 	
@@ -665,14 +661,14 @@ assert all x : Node | loops is sufficient for isDirectedTree
 			}
 		}
 		  `;
-			const forge_output = ``;
-			const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+		const forge_output = ``;
+		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-	
-			const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-			mutator.mutateToStudentUnderstanding();
-			
-		  	const expected_mutant = `
+
+		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+		mutator.mutateToStudentUnderstanding();
+
+		const expected_mutant = `
 			                  
 #lang forge
 
@@ -714,14 +710,169 @@ pred isDirectedTree_inner2 {
 pred isDirectedTree { 
  isDirectedTree_inner2 or loop
 }`;
-			assert.strictEqual(mutator.num_mutations, 2);
-			assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
-		});
+		assert.strictEqual(mutator.num_mutations, 2);
+		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+	});
 
 
-		// TODO: Quantified assertions
 
-		// TODO: All together
+	it(' : mutate to Understanding carries mutations on quantified assertions.', () => {
+
+		const tests = `
+		  
+			  #lang forge
+	
+			open "${DIRTREE_INFO.filename}"
+			//// Do not edit anything above this line ////
+		 
+			// sufficient
+			pred a1[r : Node] {
+				one Node
+				r->r not in edges
+			}
+
+			// necessary
+			pred a2[n : Node] {
+				n not in (^edges & iden)
+			}
+
+
+			test suite for isDirectedTree {
+				assert all x : Node | a1[x] is sufficient for isDirectedTree
+				assert all x : Node | a2[x] is necessary for isDirectedTree
+			}
+		  `;
+		const forge_output = "";
+		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+
+		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+		mutator.mutateToStudentUnderstanding();
+
+		const expected_mutant = `
+			#lang forge
+
+option run_sterling off
+
+sig Node {edges: set Node}
+
+pred isDirectedTree_inner1 {
+        edges.~edges in iden
+        lone edges.Node - Node.edges 
+        no (^edges & iden)
+        lone Node or Node in edges.Node + Node.edges 
+}
+
+pred a1[r : Node] {
+        one Node
+        r->r not in edges
+}
+pred a2[n : Node] {
+        n not in (^edges & iden)
+}
+
+pred isDirectedTree_inner2 { 
+                isDirectedTree_inner1 and not (all x : Node | a1[x] => isDirectedTree_inner1)
+}
+
+pred isDirectedTree { 
+                isDirectedTree_inner2 and not (all x : Node | isDirectedTree_inner2 => a2[x])
+}
+			`;
+
+		assert.strictEqual(mutator.num_mutations, 2);
+		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+	});
+
+
+
+	it(' : mutate to Understanding carries mutations out when tests are of various types.', () => {
+
+		const tests = `
+		  
+			  #lang forge
+	
+			open "${DIRTREE_INFO.filename}"
+			//// Do not edit anything above this line ////
+		 
+			// sufficient
+			pred a1[r : Node] {
+				one Node
+				r->r not in edges
+			}
+
+			pred a2 {
+				edges.~edges in iden 
+			}
+
+			example willBeIgnored is isDirectedTree for {
+				Node = \`Node1
+				no edges
+			}
+
+			test suite for isDirectedTree {
+				assert all x : Node | a1[x] is sufficient for isDirectedTree
+				assert a2 is necessary for isDirectedTree
+
+
+				example lasso is !isDirectedTree for {
+					Node = \`Node1 + \`Node2
+					edges = \`Node1->\`Node2 + \`Node2->\`Node2
+				}
+
+
+			}
+		  `;
+		const forge_output = "";
+		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+
+		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+		mutator.mutateToStudentUnderstanding();
+
+
+		const expected_mutant = `#lang forge
+
+option run_sterling off
+
+sig Node {edges: set Node}
+
+pred isDirectedTree_inner1 {
+        edges.~edges in iden
+        lone edges.Node - Node.edges 
+        no (^edges & iden)
+        lone Node or Node in edges.Node + Node.edges 
+}
+
+pred a1[r : Node] {
+        one Node
+        r->r not in edges
+}
+pred a2 {
+    edges.~edges in iden 
+}
+pred lasso {
+        some disj Node1, Node2 : Node | {
+                Node = Node1 + Node2
+                edges = Node1->Node2 + Node2->Node2
+        }
+}
+
+pred isDirectedTree_inner2 { 
+        isDirectedTree_inner1 or lasso
+}
+
+pred isDirectedTree_inner3 { 
+        isDirectedTree_inner2 and not ( isDirectedTree_inner2 => a2)
+}
+
+pred isDirectedTree { 
+        isDirectedTree_inner3 and not (all x : Node | a1[x] => isDirectedTree_inner3)
+}
+			`;
+
+		assert.strictEqual(mutator.num_mutations, 3);
+		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+	});
+
 
 });
 

--- a/client/src/test/mutator.tests.ts
+++ b/client/src/test/mutator.tests.ts
@@ -44,9 +44,6 @@ const DIRTREE_INFO = {
 					lone Node or Node in edges.Node + Node.edges 
 				}`,
 	filename: "dirTree.frg",
-
-
-
 }
 
 
@@ -54,7 +51,7 @@ const DIRTREE_INFO = {
 
 // mutator constructor(wheat: string, student_tests: string, forge_output: string, test_file_name: string, source_text : string) {
 describe('Mutator', () => {
-	it('carries out no mutations if there are no wheat failures.', () => {
+	it(' : mutate to Misunderstanding carries out no mutations if there are no wheat failures.', () => {
 
 		const tests = `
 	  
@@ -91,7 +88,7 @@ describe('Mutator', () => {
 
 
 
-	it('ignores test expects for mutations.', () => {
+	it(' : mutate to Misunderstanding ignores test expects for mutations.', () => {
 
 		const tests = `
 		
@@ -114,7 +111,7 @@ describe('Mutator', () => {
 	});
 
 
-	it('ignores examples that do not directly reference a predicate.', () => {
+	it(' : mutate to Misunderstanding ignores examples that do not directly reference a predicate.', () => {
 
 		const tests = `
 	  
@@ -155,7 +152,7 @@ describe('Mutator', () => {
 
 	});
 
-	it('can mutate on multiple assertion failures.', () => {
+	it(' : mutate to Misunderstanding can mutate on multiple assertion failures.', () => {
 
 		const tests = `
 		
@@ -229,7 +226,7 @@ describe('Mutator', () => {
 		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expectedMutant));
 	});
 
-	it('can mutate on quantified assertion failures.', () => {
+	it(' : mutate to Misunderstanding can mutate on quantified assertion failures.', () => {
 
 		const tests = `
 		#lang forge
@@ -289,7 +286,7 @@ assert all x : Node | loops is sufficient for isDirectedTree
 
 
 
-		it('carries out mutations on positive examples.', () => {
+		it(' : mutate to Misunderstanding carries out mutations on positive examples.', () => {
 	
 			const tests = `
 		  
@@ -342,7 +339,7 @@ assert all x : Node | loops is sufficient for isDirectedTree
 		});
 
 
-		it('carries out mutations on negative examples.', () => {
+		it(' : mutate to Misunderstanding carries out mutations on negative examples.', () => {
 	
 			const tests = `
 		  
@@ -394,7 +391,7 @@ assert all x : Node | loops is sufficient for isDirectedTree
 			assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
 		});
 
-		it('carries out mutations on examples and assertions when combined.', () => {
+		it(' : mutate to Misunderstanding carries out mutations on examples and assertions when combined.', () => {
 	
 			const tests = `
 		  
@@ -461,4 +458,9 @@ assert all x : Node | loops is sufficient for isDirectedTree
 	
 			assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
 		});
+
+
+
+
+		// TODO: MutateToStudentUnderstanding here
 });

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,8 +1,8 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "es2019",
-		"lib": ["ES2019", "dom"],
+		"target": "es2020",
+		"lib": ["ES2020", "dom"],
 		"outDir": "out",
 		"rootDir": "src",
 		"resolveJsonModule": true,

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
-		"target": "es2019",
-		"lib": ["ES2019"],
+		"target": "es2020",
+		"lib": ["ES2020"],
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "es2019",
-		"lib": ["ES2019"],
+		"target": "es2020",
+		"lib": ["ES2020"],
 		"outDir": "out",
 		"rootDir": "src",
 		"sourceMap": true


### PR DESCRIPTION
Adding an algorithm that allows Toadus Ponens to give throughness hints.


Lets take a set of predicates representing student beliefs:


- b1, b2, b3….that test predicate p


And lets start excluding these beliefs from tests.

```
So new p is :

p’ {
p
!b1
!b2
!b3
}


We modify all the predicates as follows. Now, we have a new mutant.

Run this mutant against the autogravder. It should fail : *all* autogravder tests. If not, we have a test we have some notion of thoroughness.

```