### PR TITLE
Excluding parameterized examples from mutated feedback

### DIFF
--- a/client/src/forge-utilities.ts
+++ b/client/src/forge-utilities.ts
@@ -24,6 +24,16 @@ export function removeForgeComments(inputText: string): string {
 	return x;
 }
 
+export function getNameUpToParameters(pred: string,): string {
+	let _pred = pred;
+	if (pred.includes('[')) {
+		_pred = pred.substring(0, pred.indexOf('['));
+	}
+	_pred = _pred.trim();
+	return _pred;
+}
+
+
 function removeCStyleComments(inputText: string): string {
 	const regex = /\/\*[\s\S]*?\*\/|\/\/.*/g;
 	return inputText.replace(regex, '');
@@ -258,6 +268,24 @@ export function assertionToExpr(lhs, rhs, op, quantifier_prefix = "") : string {
 }
 
 
+
+export function retrievePredName(pred: string, wheat : string) : Object {
+
+	var exp = new RegExp(`pred\\s+(${pred})\\b\s*([[\\s\\S]+])?`);
+	var match = wheat.match(exp);
+
+	if (match == null) {
+		return null;
+	}
+	else {
+		return {
+			predName: match[1],
+			params : match[2] || ""
+		}
+	}
+}
+
+
 // Converts an example to a predicate reflecting the characteristics of the example.
 export function exampleToPred(example, sigNames: string[], wheatPredNames : string[] ) : string {
 	
@@ -267,10 +295,10 @@ export function exampleToPred(example, sigNames: string[], wheatPredNames : stri
     const examplePredicate = example.examplePredicate;
     const exampleBody = example.exampleBody;
 
-	if (!wheatPredNames.includes(examplePredicate)) {
+	if (!wheatPredNames.includes(getNameUpToParameters(examplePredicate))) {
 		throw new Error("I provide feedback unless your example explicitly tests a predicate defined in the assignment.");
 	}
-
+	// This may be buggy!
 
 	function extractAssignments() {
 

--- a/client/src/halp.ts
+++ b/client/src/halp.ts
@@ -189,7 +189,9 @@ ${w_o}`;
 			let skipped_tests = mutator.error_messages.join("\n");
 			this.forgeOutput.appendLine(skipped_tests);
 
-
+			if (mutator.inconsistent_tests.length == 0) {
+				return [];
+			}
 			
 			this.forgeOutput.appendLine(`🐸 Step 2: I suspect that the following ${mutator.inconsistent_tests.length} test(s) may be inconsistent with the problem specification:\n ${assessed_tests}`);
 			this.forgeOutput.appendLine(`Generating feedback around these tests ⌛`);

--- a/client/src/halp.ts
+++ b/client/src/halp.ts
@@ -113,7 +113,7 @@ export class HalpRunner {
 			return "";
 		}
 
-		this.forgeOutput.appendLine('🐸 Step 1: Analyzing your tests...');
+		this.forgeOutput.appendLine('🐸 Step 1: Analyzing your tests for validity...');
 
 		const run_result = await this.runTestsAgainstModel(studentTests, w);
 		const w_o = run_result.stderr;

--- a/client/src/mutator.ts
+++ b/client/src/mutator.ts
@@ -238,12 +238,12 @@ export class Mutator {
 		// var correctlyParameterizedExamplePredicate = predInfoFromWheat['predName'] + predInfoFromWheat['params'];
 		
 		if (!wheatPredNames.includes(getNameUpToParameters(failed_example.examplePredicate))) {
-			this.error_messages.push(`I cannot provide feedback around ${failed_example.exampleName} since it does not test a predicate defined in the assignment statement.`);
+			this.error_messages.push(`Example ${failed_example.exampleName} is not consistent with the assignment. However, I cannot provide more feedback since it does not test a predicate defined in the assignment statement.`);
 			return;
 		}
 
 		if (!wheatPredNames.includes(failed_example.examplePredicate)) {
-			this.error_messages.push(`Test ${failed_example.exampleName} is not consistent with the problem statement. However, I cannot provide more detailed feedback since it tests parameterized predicate ${getNameUpToParameters(failed_example.examplePredicate)}.`);
+			this.error_messages.push(`Example ${failed_example.exampleName} is not consistent with the problem statement. However, I cannot provide more detailed feedback since it tests parameterized predicate ${getNameUpToParameters(failed_example.examplePredicate)}.`);
 			return;
 		}
 

--- a/client/src/mutator.ts
+++ b/client/src/mutator.ts
@@ -234,7 +234,7 @@ export class Mutator {
 
 		// TODO: Fix
 		if (!wheatPredNames.includes(failed_example.examplePredicate)) {
-			this.error_messages.push(`I cannot provide feedback around ${failed_example.exampleName} since it does not test a predicate defined in the assignment statement.`);
+			this.error_messages.push(`I cannot provide feedback around ${failed_example.exampleName} since it does not test a predicate defined in the assignment statement, or perhaps tests a parameterized predicate.`);
 			return;
 		}
 
@@ -352,13 +352,6 @@ export class Mutator {
 					}
 					
 					let p = exampleToPred(example, getSigList(this.wheat), getPredList(this.wheat));
-
-
-					
-					let targetPredInfo = retrievePredName(getNameUpToParameters(example['examplePredicate']), this.wheat);
-
-					let exampleName = getNameUpToParameters(example['exampleName']) + targetPredInfo['params'];
-
 					predicates_to_add_to_mutation.push(p);
 					expressions_in_mutation.push({ "name": example['exampleName'], "expression": example['exampleName'], predicate_under_test: getNameUpToParameters(example['examplePredicate']), isNegativeTest: pred_info.isNegation });
 				}

--- a/client/src/mutator.ts
+++ b/client/src/mutator.ts
@@ -222,7 +222,7 @@ export class Mutator {
 		const sigNames = getSigList(this.wheat);
 		const wheatPredNames = getPredList(this.wheat);
 
-		this.inconsistent_tests.push(failed_example.exampleName);
+
 		// TODO: Potential ISSUE: What if they wrap the negation in () or extra {}? 
 		const negationRegex = /(not|!)\s+(\b\w+\b)/;
 		const isNegation = failed_example.examplePredicate.match(negationRegex);
@@ -232,19 +232,22 @@ export class Mutator {
 			failed_example.examplePredicate = isNegation[2];
 		}
 
+		// Better messaging
 		// This makes a best effort to adjust for parameterized predicates.
-		var predInfoFromWheat = retrievePredName(getNameUpToParameters(failed_example.examplePredicate), this.wheat);
-		var correctlyParameterizedExamplePredicate = predInfoFromWheat['predName'] + predInfoFromWheat['params'];
+		// var predInfoFromWheat = retrievePredName(getNameUpToParameters(failed_example.examplePredicate), this.wheat);
+		// var correctlyParameterizedExamplePredicate = predInfoFromWheat['predName'] + predInfoFromWheat['params'];
 		
 		if (!wheatPredNames.includes(getNameUpToParameters(failed_example.examplePredicate))) {
 			this.error_messages.push(`I cannot provide feedback around ${failed_example.exampleName} since it does not test a predicate defined in the assignment statement.`);
 			return;
 		}
 
-		// if (!wheatPredNames.includes(failed_example.examplePredicate)) {
-		// 	this.error_messages.push(`I cannot provide feedback around ${failed_example.exampleName} since it tests a parameterized predicate.`);
-		// 	return;
-		// }
+		if (!wheatPredNames.includes(failed_example.examplePredicate)) {
+			this.error_messages.push(`Test ${failed_example.exampleName} is not consistent with the problem statement. However, I cannot provide more detailed feedback since it tests parameterized predicate ${getNameUpToParameters(failed_example.examplePredicate)}.`);
+			return;
+		}
+
+		this.inconsistent_tests.push(failed_example.exampleName);
 
 		const exampleAsPred = exampleToPred(failed_example, sigNames, wheatPredNames);
 		let mutant_with_example = this.mutant + "\n" + exampleAsPred + "\n";

--- a/client/src/mutator.ts
+++ b/client/src/mutator.ts
@@ -232,11 +232,19 @@ export class Mutator {
 			failed_example.examplePredicate = isNegation[2];
 		}
 
-		// TODO: Fix
-		if (!wheatPredNames.includes(failed_example.examplePredicate)) {
-			this.error_messages.push(`I cannot provide feedback around ${failed_example.exampleName} since it does not test a predicate defined in the assignment statement, or perhaps tests a parameterized predicate.`);
+		// This makes a best effort to adjust for parameterized predicates.
+		var predInfoFromWheat = retrievePredName(getNameUpToParameters(failed_example.examplePredicate), this.wheat);
+		var correctlyParameterizedExamplePredicate = predInfoFromWheat['predName'] + predInfoFromWheat['params'];
+		
+		if (!wheatPredNames.includes(getNameUpToParameters(failed_example.examplePredicate))) {
+			this.error_messages.push(`I cannot provide feedback around ${failed_example.exampleName} since it does not test a predicate defined in the assignment statement.`);
 			return;
 		}
+
+		// if (!wheatPredNames.includes(failed_example.examplePredicate)) {
+		// 	this.error_messages.push(`I cannot provide feedback around ${failed_example.exampleName} since it tests a parameterized predicate.`);
+		// 	return;
+		// }
 
 		const exampleAsPred = exampleToPred(failed_example, sigNames, wheatPredNames);
 		let mutant_with_example = this.mutant + "\n" + exampleAsPred + "\n";

--- a/client/src/test/mutator.tests.ts
+++ b/client/src/test/mutator.tests.ts
@@ -1,8 +1,5 @@
 import { Mutator } from '../mutator';
 import { removeForgeComments } from '../forge-utilities';
-
-
-
 import { strict as assert, strictEqual } from 'assert';
 
 // TODO: This is duplicated, find a better place to put it.


### PR DESCRIPTION
Toadus Ponens currently does not support mutation on parameterized examples