### PR TITLE
Multifaceted mutation

### DIFF
--- a/client/src/forge-utilities.ts
+++ b/client/src/forge-utilities.ts
@@ -48,11 +48,20 @@ function removeInlineComments(inputText: string): string {
 // Need to test this, but hopefully works.
 function findForgePredicates(inputText : string) : [string] {
 	const withoutComments = removeForgeComments(inputText);
+
+	//// AHH, we shouldn't split!
     const lines = withoutComments.split('\n');
+
+
+	withoutComments.matchAll(predicatePattern);
+
+
     let inPredicate = false;
     let braceLevel = 0;
     let currentPredicate = '';
     let predicates : [string] = [''];
+
+
 
     for (let line of lines) {
         if (inPredicate) {
@@ -60,13 +69,24 @@ function findForgePredicates(inputText : string) : [string] {
             braceLevel += (line.match(/\{/g) || []).length;
             braceLevel -= (line.match(/\}/g) || []).length;
 
-            if (braceLevel === 0) {
+            if (braceLevel == 0) {
+
+				
+
+
                 predicates.push(currentPredicate.trim());
                 currentPredicate = '';
                 inPredicate = false;
+
+				
+
             }
         } else {
-            const match = line.match(/\bpred\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*(\[(.*?)\])?\s*\{/);
+            //const match = line.match(/\bpred\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*(\[(.*?)\])?\s*\{/);
+			const match =  line.match(predicatePattern);
+
+			console.log("Checking line " + line + "and it matched? " + (match != null));
+
             if (match) {
                 inPredicate = true;
                 braceLevel = 1;
@@ -118,7 +138,7 @@ export const assertion_regex = /Theorem Assertion[ _](\w+)[ _]is[ _](\w+)[ _]for
 export const example_regex = /Invalid example '(\w+)'; the instance specified does not satisfy the given predicate\./;
 export const test_regex = /Failed test (\w+)\.|Theorem (\w+) failed/;
 
-
+const predicatePattern =  /pred\s+([^]*?){/;
 
 export function getSigList(s : string) : string[] {
 	const pattern = /\bsig\s+(\w+)/g;
@@ -222,9 +242,6 @@ export function findAllQuantifiedAssertions(fileContent : string) {
     }
     return assertions;
 }
-
-
-
 
 
 export function findExampleByName(fileContent : string, exampleName: string) {
@@ -544,8 +561,6 @@ export function extractTestSuite(input: string): ExtractedTestSuite[] {
 			}
 		}
 		const remaining = input.substring(suiteEnd);
-		console.log(remaining);
-
 		return indices;
 	}
 	  
@@ -693,7 +708,7 @@ export function emptyOutPredicate(wheat : string, predicateName: string) {
 
 	predicates.forEach(predicate => {
 		// Match the predicate up to the first opening brace '{'
-		const predicateStartRegex = predicate.match(/(pred\s+[a-zA-Z_][a-zA-Z0-9_]*\s*(\[(.*?)\])?[\s\S]*)\{/);
+		const predicateStartRegex = predicate.match(predicatePattern);
 		if (predicateStartRegex) {
 			const predicateStart = predicateStartRegex[0];
 			const predicateBodyStartIndex = predicate.indexOf(predicateStart) + predicateStart.length;
@@ -715,13 +730,19 @@ export function emptyOutPredicate(wheat : string, predicateName: string) {
 
 
 
+
+
 export function emptyOutAllPredicates(code : string) {
 	const predicates = findForgePredicates( code);
 	let outputText =  code;
 
 	predicates.forEach(predicate => {
+
+
+		console.log(predicate)
+
 		// Match the predicate up to the first opening brace '{'
-		const predicateStartRegex = predicate.match(/(pred\s+[a-zA-Z_][a-zA-Z0-9_]*\s*(\[(.*?)\])?[\s\S]*)\{/);
+		const predicateStartRegex = predicate.match(predicatePattern);
 		if (predicateStartRegex) {
 			const predicateStart = predicateStartRegex[0];
 			const predicateBodyStartIndex = predicate.indexOf(predicateStart) + predicateStart.length;

--- a/client/src/forge-utilities.ts
+++ b/client/src/forge-utilities.ts
@@ -710,5 +710,5 @@ export function emptyOutPredicate(wheat : string, predicateName: string) {
 		}
 	});
 
-	 wheat = outputText;
+	return outputText;
 }

--- a/client/src/forge-utilities.ts
+++ b/client/src/forge-utilities.ts
@@ -49,11 +49,8 @@ function removeInlineComments(inputText: string): string {
 function findForgePredicates(inputText : string) : [string] {
 	const withoutComments = removeForgeComments(inputText);
 
-	//// AHH, we shouldn't split!
+
     const lines = withoutComments.split('\n');
-
-
-	withoutComments.matchAll(predicatePattern);
 
 
     let inPredicate = false;
@@ -64,6 +61,7 @@ function findForgePredicates(inputText : string) : [string] {
 
 
     for (let line of lines) {
+
         if (inPredicate) {
             currentPredicate += line + '\n';
             braceLevel += (line.match(/\{/g) || []).length;
@@ -71,25 +69,19 @@ function findForgePredicates(inputText : string) : [string] {
 
             if (braceLevel == 0) {
 
-				
-
-
                 predicates.push(currentPredicate.trim());
                 currentPredicate = '';
                 inPredicate = false;
-
-				
-
             }
         } else {
-            //const match = line.match(/\bpred\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*(\[(.*?)\])?\s*\{/);
+
 			const match =  line.match(predicatePattern);
 
-			console.log("Checking line " + line + "and it matched? " + (match != null));
+			
 
             if (match) {
                 inPredicate = true;
-                braceLevel = 1;
+                braceLevel = (line.match(/\{/g) || []).length;;
                 currentPredicate = line + '\n';
             }
         }
@@ -123,7 +115,7 @@ export function findForgeExamples(inputText) {
             const match = line.match(/\bexample\s+([a-zA-Z_][a-zA-Z0-9_]*)\s+is\s+(.*?)\s+for\s*\{/);
             if (match) {
                 inExample = true;
-                braceLevel = 1;
+                braceLevel = 1;  
                 currentExample = line + '\n';
             }
         }
@@ -138,7 +130,7 @@ export const assertion_regex = /Theorem Assertion[ _](\w+)[ _]is[ _](\w+)[ _]for
 export const example_regex = /Invalid example '(\w+)'; the instance specified does not satisfy the given predicate\./;
 export const test_regex = /Failed test (\w+)\.|Theorem (\w+) failed/;
 
-const predicatePattern =  /pred\s+([^]*?){/;
+const predicatePattern =  /pred\s+([^]*?)({|\n|$)/;
 
 export function getSigList(s : string) : string[] {
 	const pattern = /\bsig\s+(\w+)/g;
@@ -717,7 +709,10 @@ export function emptyOutPredicate(wheat : string, predicateName: string) {
 			const predDecl = new RegExp(`pred\\s+\\b${predicateName}\\b`);
 			if (predicate.match(predDecl)) {
 				// Construct the new predicate with an empty body
-				const newPredicate = `${predicate.substring(0, predicateBodyStartIndex)}}${predicate.substring(predicateBodyEndIndex + 1)}`;
+
+				const predicate_beginning = predicate.substring(0, predicateBodyStartIndex);
+				let predicate_body = predicateStart.includes('{') ? '}' : ' { }';
+				const newPredicate = `${predicate_beginning}${predicate_body}${predicate.substring(predicateBodyEndIndex + 1)}`;
 				// Replace the original predicate in the output text
 				outputText = outputText.replace(predicate, newPredicate);
 			}
@@ -739,8 +734,6 @@ export function emptyOutAllPredicates(code : string) {
 	predicates.forEach(predicate => {
 
 
-		console.log(predicate)
-
 		// Match the predicate up to the first opening brace '{'
 		const predicateStartRegex = predicate.match(predicatePattern);
 		if (predicateStartRegex) {
@@ -748,7 +741,9 @@ export function emptyOutAllPredicates(code : string) {
 			const predicateBodyStartIndex = predicate.indexOf(predicateStart) + predicateStart.length;
 			const predicateBodyEndIndex = predicate.lastIndexOf('}');
 			// Construct the new predicate with an empty body
-			const newPredicate = `${predicate.substring(0, predicateBodyStartIndex)}}${predicate.substring(predicateBodyEndIndex + 1)}`;
+			const predicate_beginning = predicate.substring(0, predicateBodyStartIndex);
+			let predicate_body = predicateStart.includes('{') ? '}' : ' { }';
+			const newPredicate = `${predicate_beginning}${predicate_body}${predicate.substring(predicateBodyEndIndex + 1)}`;
 			// Replace the original predicate in the output text
 			outputText = outputText.replace(predicate, newPredicate);
 		}

--- a/client/src/forge-utilities.ts
+++ b/client/src/forge-utilities.ts
@@ -712,3 +712,26 @@ export function emptyOutPredicate(wheat : string, predicateName: string) {
 
 	return outputText;
 }
+
+
+
+export function emptyOutAllPredicates(code : string) {
+	const predicates = findForgePredicates( code);
+	let outputText =  code;
+
+	predicates.forEach(predicate => {
+		// Match the predicate up to the first opening brace '{'
+		const predicateStartRegex = predicate.match(/(pred\s+[a-zA-Z_][a-zA-Z0-9_]*\s*(\[(.*?)\])?[\s\S]*)\{/);
+		if (predicateStartRegex) {
+			const predicateStart = predicateStartRegex[0];
+			const predicateBodyStartIndex = predicate.indexOf(predicateStart) + predicateStart.length;
+			const predicateBodyEndIndex = predicate.lastIndexOf('}');
+			// Construct the new predicate with an empty body
+			const newPredicate = `${predicate.substring(0, predicateBodyStartIndex)}}${predicate.substring(predicateBodyEndIndex + 1)}`;
+			// Replace the original predicate in the output text
+			outputText = outputText.replace(predicate, newPredicate);
+		}
+	});
+
+	return outputText;
+}

--- a/client/src/forge-utilities.ts
+++ b/client/src/forge-utilities.ts
@@ -678,3 +678,37 @@ export function combineTestsWithModel(wheatText: string, tests: string): string 
 	return combined;
 
 }
+
+
+
+export function emptyOutPredicate(wheat : string, predicateName: string) {
+	const predicates = findForgePredicates( wheat);
+	let outputText =  wheat;
+
+
+	if (predicateName.includes('[')) {
+		predicateName = predicateName.substring(0, predicateName.indexOf('['));
+	}
+	predicateName = predicateName.trim();
+
+	predicates.forEach(predicate => {
+		// Match the predicate up to the first opening brace '{'
+		const predicateStartRegex = predicate.match(/(pred\s+[a-zA-Z_][a-zA-Z0-9_]*\s*(\[(.*?)\])?[\s\S]*)\{/);
+		if (predicateStartRegex) {
+			const predicateStart = predicateStartRegex[0];
+			const predicateBodyStartIndex = predicate.indexOf(predicateStart) + predicateStart.length;
+			const predicateBodyEndIndex = predicate.lastIndexOf('}');
+
+			const predDecl = new RegExp(`pred\\s+\\b${predicateName}\\b`);
+			if (predicate.match(predDecl)) {
+				// Construct the new predicate with an empty body
+				const newPredicate = `${predicate.substring(0, predicateBodyStartIndex)}}${predicate.substring(predicateBodyEndIndex + 1)}`;
+				// Replace the original predicate in the output text
+				outputText = outputText.replace(predicate, newPredicate);
+			}
+
+		}
+	});
+
+	 wheat = outputText;
+}

--- a/client/src/halp.ts
+++ b/client/src/halp.ts
@@ -462,9 +462,10 @@ ${w_o}`;
 		let skipped_tests = positiveMutator.error_messages.join("\n") + negativeMutator.error_messages.join("\n");
 		this.forgeOutput.appendLine(skipped_tests);
 
+		let tests_analyzed = positiveMutator.num_mutations + negativeMutator.num_mutations;
 
 		// There should be one mutation per considered, consistent test
-		this.forgeOutput.appendLine(`🐸 Step 3: Generating a hint to help you improve test thoroughness, with the remaining ${mutator.num_mutations} tests in mind. ⌛\n`);
+		this.forgeOutput.appendLine(`🐸 Step 3: Generating a hint to help you improve test thoroughness, with the remaining ${tests_analyzed} tests in mind. ⌛\n`);
 		this.forgeOutput.show();
 		try {
 			let thoroughness_hints = await this.tryGetThoroughnessFromMutant(positiveMutator.test_file_name, positiveMutator.mutant, positiveMutator.student_preds);

--- a/client/src/halp.ts
+++ b/client/src/halp.ts
@@ -432,47 +432,47 @@ ${w_o}`;
 
 		this.forgeOutput.appendLine(CONSISTENCY_MESSAGE);
 		this.forgeOutput.appendLine(`🐸 Step 2: Asessing the thoroughness of your test-suite. I will ignore ANY tests that are not in 'test-suite's`);
-
-		// Flush the output
 		this.forgeOutput.show();
 
+		/*
+			- For each test-suite, identify the predicate being tested.
+			- For each test in the suite.
+				- Produce a predicate that characterizes the test.
+				- Exclude these predicates from the predicate under test.
+		*/
 
-
-
-
-			/*
-				- For each test-suite, identify the predicate being tested.
-				- For each test in the suite.
-					- Produce a predicate that characterizes the test.
-					- Exclude these predicates from the predicate under test.
-			*/
-
+	
+		var positiveMutator = new Mutator(mutator.wheat, mutator.student_tests, mutator.forge_output, mutator.test_file_name, mutator.source_text);
+		var negativeMutator = new Mutator(mutator.wheat, mutator.student_tests, mutator.forge_output, mutator.test_file_name, mutator.source_text);
 		
+
+		positiveMutator.mutateToPositiveTests();
+		negativeMutator.mutateToNegativeTests();
+
+
 		// Now we have all the positive tests
 		// And all the negative tests
 
 
-		// We should segregate the test suite into both positive and negative tests.
-		// Positive tests should have a destructive approach and run
 
-		// Negative tests should have a constructive approach and run
-
-		// If an ag test passes *both*, it is a thoroughness candidate.
+		// If an ag test passes positive AND fails negative, it is a thoroughness candidate.
 
 
 
-
-
-
-		mutator.mutateToStudentUnderstanding();
-		let skipped_tests = mutator.error_messages.join("\n");
+		let skipped_tests = positiveMutator.error_messages.join("\n") + negativeMutator.error_messages.join("\n");
 		this.forgeOutput.appendLine(skipped_tests);
+
+
 		// There should be one mutation per considered, consistent test
 		this.forgeOutput.appendLine(`🐸 Step 3: Generating a hint to help you improve test thoroughness, with the remaining ${mutator.num_mutations} tests in mind. ⌛\n`);
 		this.forgeOutput.show();
 		try {
-			let thoroughness_hints = await this.tryGetThoroughnessFromMutant(mutator.test_file_name, mutator.mutant, mutator.student_preds);
-			return thoroughness_hints;
+			let thoroughness_hints = await this.tryGetThoroughnessFromMutant(positiveMutator.test_file_name, positiveMutator.mutant, positiveMutator.student_preds);
+			let negative_thoroughness_hints = await this.tryGetHintsFromMutant(negativeMutator.test_file_name, negativeMutator.mutant, negativeMutator.student_preds, negativeMutator.forge_output);
+			
+			
+			const intersection = thoroughness_hints.filter(hint => negative_thoroughness_hints.includes(hint));
+			return intersection;
 		}
 		catch (e) {
 			vscode.window.showErrorMessage(this.SOMETHING_WENT_WRONG);

--- a/client/src/halp.ts
+++ b/client/src/halp.ts
@@ -436,6 +436,34 @@ ${w_o}`;
 		// Flush the output
 		this.forgeOutput.show();
 
+
+
+
+
+			/*
+				- For each test-suite, identify the predicate being tested.
+				- For each test in the suite.
+					- Produce a predicate that characterizes the test.
+					- Exclude these predicates from the predicate under test.
+			*/
+
+		
+		// Now we have all the positive tests
+		// And all the negative tests
+
+
+		// We should segregate the test suite into both positive and negative tests.
+		// Positive tests should have a destructive approach and run
+
+		// Negative tests should have a constructive approach and run
+
+		// If an ag test passes *both*, it is a thoroughness candidate.
+
+
+
+
+
+
 		mutator.mutateToStudentUnderstanding();
 		let skipped_tests = mutator.error_messages.join("\n");
 		this.forgeOutput.appendLine(skipped_tests);

--- a/client/src/halp.ts
+++ b/client/src/halp.ts
@@ -450,15 +450,6 @@ ${w_o}`;
 		negativeMutator.mutateToNegativeTests();
 
 
-		// Now we have all the positive tests
-		// And all the negative tests
-
-
-
-		// If an ag test passes positive AND fails negative, it is a thoroughness candidate.
-
-
-
 		let skipped_tests = positiveMutator.error_messages.join("\n") + negativeMutator.error_messages.join("\n");
 		this.forgeOutput.appendLine(skipped_tests);
 
@@ -469,9 +460,7 @@ ${w_o}`;
 		this.forgeOutput.show();
 		try {
 			let thoroughness_hints = await this.tryGetThoroughnessFromMutant(positiveMutator.test_file_name, positiveMutator.mutant, positiveMutator.student_preds);
-			let negative_thoroughness_hints = await this.tryGetHintsFromMutant(negativeMutator.test_file_name, negativeMutator.mutant, negativeMutator.student_preds, negativeMutator.forge_output);
-			
-			
+			let negative_thoroughness_hints = await this.tryGetHintsFromMutant(negativeMutator.test_file_name, negativeMutator.mutant, negativeMutator.student_preds, negativeMutator.forge_output);	
 			const intersection = thoroughness_hints.filter(hint => negative_thoroughness_hints.includes(hint));
 			return intersection;
 		}

--- a/client/src/mutator.ts
+++ b/client/src/mutator.ts
@@ -1,5 +1,5 @@
 import { info } from 'console';
-import { getNameUpToParameters, example_regex, assertion_regex, quantified_assertion_regex, extractTestSuite, assertionToExpr, emptyOutPredicate } from './forge-utilities';
+import { getNameUpToParameters, example_regex, assertion_regex, quantified_assertion_regex, extractTestSuite, assertionToExpr, emptyOutPredicate, emptyOutAllPredicates } from './forge-utilities';
 import { getPredicatesOnly, removeForgeComments, exampleToPred, getSigList, getPredList, findExampleByName, test_regex, getFailingTestName, retrievePredName } from './forge-utilities';
 
 
@@ -564,6 +564,12 @@ export class Mutator {
 				this.mutant = this.constrainPredicateByExclusion(this.mutant, e['predicate_under_test'], e['expression']);
 			}
 		}
+	}
+
+
+
+	mutateToVaccuity() {
+		this.mutant = emptyOutAllPredicates(this.mutant);
 	}
 }
 

--- a/client/src/test/mutator.tests.ts
+++ b/client/src/test/mutator.tests.ts
@@ -862,7 +862,7 @@ pred isDirectedTree {
 
         const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
         mutator.mutateToPositiveTests();
-            console.log(mutator.mutant);
+
             
         const expected_mutant = `
         #lang forge
@@ -900,3 +900,54 @@ pred a2 {
 });
 
 
+describe('Mutator to Vaccuity', () => {
+    it(' : mutate to Vaccuity removes all predicate bodies', () => {
+
+        const source = `
+      
+        #lang forge
+
+        option run_sterling off
+
+        sig Node {edges: set Node}
+
+        pred isDirectedTree {
+            edges.~edges in iden
+            lone edges.Node - Node.edges 
+            no (^edges & iden)
+            lone Node or Node in edges.Node + Node.edges 
+        }
+
+
+        pred isDir [n : Node] {
+            n in Node
+        }
+
+        pred abc [n : Node, n2 : Node] 
+        {
+            n1 = n2
+        }
+
+      `;
+        const expectedMutant = `        #lang forge
+
+        option run_sterling off
+
+        sig Node {edges: set Node}
+
+        pred isDirectedTree {   }
+
+
+        pred isDir [n : Node] { }
+
+        pred abc [n : Node, n2 : Node] 
+        {
+        }
+`;
+
+
+        const mutator = new Mutator(source, "", "", "", "");
+        mutator.mutateToVaccuity();
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expectedMutant));
+    });
+});

--- a/client/src/test/mutator.tests.ts
+++ b/client/src/test/mutator.tests.ts
@@ -4,42 +4,42 @@ import { strict as assert, strictEqual } from 'assert';
 
 // TODO: This is duplicated, find a better place to put it.
 export function combineTestsWithModel(wheatText: string, tests: string): string {
-	const TEST_SEPARATOR = "//// Do not edit anything above this line ////"
-	const hashlang_decl = "#lang";
+    const TEST_SEPARATOR = "//// Do not edit anything above this line ////"
+    const hashlang_decl = "#lang";
 
-	if (tests.includes(TEST_SEPARATOR)) {
-		const startIndex = tests.indexOf(TEST_SEPARATOR) + TEST_SEPARATOR.length;
-		tests = tests.substring(startIndex).trim();
-	}
-	tests = tests.replace(hashlang_decl, "// #lang");
+    if (tests.includes(TEST_SEPARATOR)) {
+        const startIndex = tests.indexOf(TEST_SEPARATOR) + TEST_SEPARATOR.length;
+        tests = tests.substring(startIndex).trim();
+    }
+    tests = tests.replace(hashlang_decl, "// #lang");
 
-	var combined = wheatText + "\n" + tests;
-	combined = removeForgeComments(combined);
+    var combined = wheatText + "\n" + tests;
+    combined = removeForgeComments(combined);
 
-	return combined;
+    return combined;
 
 }
 
 function removeWhitespace(str: string): string {
-	return str.replace(/\s/g, '');
+    return str.replace(/\s/g, '');
 }
 
 
 const DIRTREE_INFO = {
 
-	wheat: `#lang forge
+    wheat: `#lang forge
 
-				option run_sterling off
+                option run_sterling off
 
-				sig Node {edges: set Node}
+                sig Node {edges: set Node}
 
-				pred isDirectedTree {
-					edges.~edges in iden
-					lone edges.Node - Node.edges 
-					no (^edges & iden)
-					lone Node or Node in edges.Node + Node.edges 
-				}`,
-	filename: "dirTree.frg",
+                pred isDirectedTree {
+                    edges.~edges in iden
+                    lone edges.Node - Node.edges 
+                    no (^edges & iden)
+                    lone Node or Node in edges.Node + Node.edges 
+                }`,
+    filename: "dirTree.frg",
 }
 
 
@@ -47,181 +47,181 @@ const DIRTREE_INFO = {
 
 // mutator constructor(wheat: string, student_tests: string, forge_output: string, test_file_name: string, source_text : string) {
 describe('Mutator to Misunderstanding', () => {
-	it(' : mutate to Misunderstanding carries out no mutations if there are no wheat failures.', () => {
+    it(' : mutate to Misunderstanding carries out no mutations if there are no wheat failures.', () => {
 
-		const tests = `
-	  
-	  	#lang forge
+        const tests = `
+      
+          #lang forge
 
-		open "${DIRTREE_INFO.filename}"
-		//// Do not edit anything above this line ////
-	 
-	  test expect {
-		injective : {isDirectedTree implies (edges.~edges in iden)} is theorem
-		injective_insufficient : {(edges.~edges in iden) and !isDirectedTree} is sat
-	  
-		root : {isDirectedTree implies (lone edges.Node - Node.edges) } is theorem
-		loopless : {isDirectedTree implies (no (^edges & iden))} is theorem
-		connected : {isDirectedTree implies (lone Node or Node in edges.Node + Node.edges) } is theorem
-	  }
-	  
-	  example twoNodeTree is isDirectedTree for {
-		Node = \`Node1 + \`Node2
-		edges = \`Node1->\`Node2
-	  }
-	  `;
-		const forge_output = "";
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+        open "${DIRTREE_INFO.filename}"
+        //// Do not edit anything above this line ////
+     
+      test expect {
+        injective : {isDirectedTree implies (edges.~edges in iden)} is theorem
+        injective_insufficient : {(edges.~edges in iden) and !isDirectedTree} is sat
+      
+        root : {isDirectedTree implies (lone edges.Node - Node.edges) } is theorem
+        loopless : {isDirectedTree implies (no (^edges & iden))} is theorem
+        connected : {isDirectedTree implies (lone Node or Node in edges.Node + Node.edges) } is theorem
+      }
+      
+      example twoNodeTree is isDirectedTree for {
+        Node = \`Node1 + \`Node2
+        edges = \`Node1->\`Node2
+      }
+      `;
+        const forge_output = "";
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToStudentMisunderstanding();
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(DIRTREE_INFO.wheat));
-	});
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToStudentMisunderstanding();
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(DIRTREE_INFO.wheat));
+    });
 
 
 
-	it(' : mutate to Misunderstanding ignores test expects for mutations.', () => {
+    it(' : mutate to Misunderstanding ignores test expects for mutations.', () => {
 
-		const tests = `
-		
-			#lang forge
+        const tests = `
+        
+            #lang forge
   
-		  open "${DIRTREE_INFO.filename}"
-		  //// Do not edit anything above this line ////
-	   
-		test expect {
-		  contradiction : {isDirectedTree and !isDirectedTree } is sat
-		}`;
-		const forge_output = "";
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+          open "${DIRTREE_INFO.filename}"
+          //// Do not edit anything above this line ////
+       
+        test expect {
+          contradiction : {isDirectedTree and !isDirectedTree } is sat
+        }`;
+        const forge_output = "";
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToStudentMisunderstanding();
-
-
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(DIRTREE_INFO.wheat));
-	});
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToStudentMisunderstanding();
 
 
-	it(' : mutate to Misunderstanding ignores examples that do not directly reference a predicate.', () => {
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(DIRTREE_INFO.wheat));
+    });
 
-		const tests = `
-	  
-	  	#lang forge
 
-		open "${DIRTREE_INFO.filename}"
-		//// Do not edit anything above this line ////
-	 
+    it(' : mutate to Misunderstanding ignores examples that do not directly reference a predicate.', () => {
 
-	  
-	  example someexamplename1 is {all t : Node | isDirectedTree } for {
-		Node = \`Node1 + \`Node2
-		no edges
-	  }
+        const tests = `
+      
+          #lang forge
 
-	  pred anotherPred {
-		  some edges
-	  }
+        open "${DIRTREE_INFO.filename}"
+        //// Do not edit anything above this line ////
+     
 
-	  example someexamplename2 is anotherPred for {
-		Node = \`Node1 
-		no edges
-	  }
+      
+      example someexamplename1 is {all t : Node | isDirectedTree } for {
+        Node = \`Node1 + \`Node2
+        no edges
+      }
 
-	  `;
-		const forge_output = "";
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+      pred anotherPred {
+          some edges
+      }
 
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToStudentMisunderstanding();
-		assert.strictEqual(mutator.num_mutations, 0);
+      example someexamplename2 is anotherPred for {
+        Node = \`Node1 
+        no edges
+      }
 
-		let outputs = mutator.error_messages;
+      `;
+        const forge_output = "";
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-		for (let output of outputs) {
-			assert.strict(output.includes('someexamplename1') || output.includes('someexamplename'));
-		}
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToStudentMisunderstanding();
+        assert.strictEqual(mutator.num_mutations, 0);
 
-	});
+        let outputs = mutator.error_messages;
 
-	it(' : mutate to Misunderstanding can mutate on multiple assertion failures.', () => {
+        for (let output of outputs) {
+            assert.strict(output.includes('someexamplename1') || output.includes('someexamplename'));
+        }
 
-		const tests = `
-		
-			#lang forge
+    });
+
+    it(' : mutate to Misunderstanding can mutate on multiple assertion failures.', () => {
+
+        const tests = `
+        
+            #lang forge
   
-		  open "${DIRTREE_INFO.filename}"
-		  //// Do not edit anything above this line ////
-	   
+          open "${DIRTREE_INFO.filename}"
+          //// Do not edit anything above this line ////
+       
 
-		  pred loops {
+          pred loops {
     
-			(some (^edges & iden))
-			}
-	   
-	   assert loops is necessary for isDirectedTree
-	   
-	   
-	   pred mustHaveRoot {
-	   
-		   one edges.Node - Node.edges
-	   }
-	   
-	   assert mustHaveRoot is necessary for isDirectedTree
-		  `;
-		const forge_output = `[hQNVMlZUHG.rkt:18:0 (span 44)] Theorem Assertion_loops_is_necessary_for_isDirectedTree failed. Found instance:
-		#(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 388) (size-clauses 555) (size-primary 20) (time-translation 90) (time-solving 9) (time-building 1708532242901)) ()) Sterling disabled, so reporting raw instance data:
-		#(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 388) (size-clauses 555) (size-primary 20) (time-translation 90) (time-solving 9) (time-building 1708532242901)) ())
-		
-		[hQNVMlZUHG.rkt:26:0 (span 51)] Theorem Assertion_mustHaveRoot_is_necessary_for_isDirectedTree failed. Found instance:
-		#(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 390) (size-clauses 604) (size-primary 20) (time-translation 27) (time-solving 6) (time-building 1708532243034)) ()) Sterling disabled, so reporting raw instance data:
-		#(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 390) (size-clauses 604) (size-primary 20) (time-translation 27) (time-solving 6) (time-building 1708532243034)) ())
+            (some (^edges & iden))
+            }
+       
+       assert loops is necessary for isDirectedTree
+       
+       
+       pred mustHaveRoot {
+       
+           one edges.Node - Node.edges
+       }
+       
+       assert mustHaveRoot is necessary for isDirectedTree
+          `;
+        const forge_output = `[hQNVMlZUHG.rkt:18:0 (span 44)] Theorem Assertion_loops_is_necessary_for_isDirectedTree failed. Found instance:
+        #(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 388) (size-clauses 555) (size-primary 20) (time-translation 90) (time-solving 9) (time-building 1708532242901)) ()) Sterling disabled, so reporting raw instance data:
+        #(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 388) (size-clauses 555) (size-primary 20) (time-translation 90) (time-solving 9) (time-building 1708532242901)) ())
+        
+        [hQNVMlZUHG.rkt:26:0 (span 51)] Theorem Assertion_mustHaveRoot_is_necessary_for_isDirectedTree failed. Found instance:
+        #(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 390) (size-clauses 604) (size-primary 20) (time-translation 27) (time-solving 6) (time-building 1708532243034)) ()) Sterling disabled, so reporting raw instance data:
+        #(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 390) (size-clauses 604) (size-primary 20) (time-translation 27) (time-solving 6) (time-building 1708532243034)) ())
 
-		`;
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+        `;
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		let num_mutations = mutator.mutateToStudentMisunderstanding();
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        let num_mutations = mutator.mutateToStudentMisunderstanding();
 
 
 
-		const expectedMutant = `#lang forge
+        const expectedMutant = `#lang forge
 
-	  option run_sterling off
-	  
-	  sig Node {edges: set Node}
-	  
-	  pred isDirectedTree_inner1 {
-		edges.~edges in iden 
-		lone edges.Node - Node.edges 
-		no (^edges & iden) 
-		lone Node or Node in edges.Node + Node.edges 
-	  }
-	  
-	  pred loops {
-		   (some (^edges & iden))
-	  }
-	  pred mustHaveRoot {
-	  
-		  one edges.Node - Node.edges
-	  }
-	  
-			pred isDirectedTree_inner2 { 
-				 isDirectedTree_inner1 and loops
-			}
-			
-			pred isDirectedTree { 
-				 isDirectedTree_inner2 and mustHaveRoot
-			}`;
+      option run_sterling off
+      
+      sig Node {edges: set Node}
+      
+      pred isDirectedTree_inner1 {
+        edges.~edges in iden 
+        lone edges.Node - Node.edges 
+        no (^edges & iden) 
+        lone Node or Node in edges.Node + Node.edges 
+      }
+      
+      pred loops {
+           (some (^edges & iden))
+      }
+      pred mustHaveRoot {
+      
+          one edges.Node - Node.edges
+      }
+      
+            pred isDirectedTree_inner2 { 
+                 isDirectedTree_inner1 and loops
+            }
+            
+            pred isDirectedTree { 
+                 isDirectedTree_inner2 and mustHaveRoot
+            }`;
 
-		assert.strictEqual(num_mutations, 2);
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expectedMutant));
-	});
+        assert.strictEqual(num_mutations, 2);
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expectedMutant));
+    });
 
-	it(' : mutate to Misunderstanding can mutate on quantified assertion failures.', () => {
+    it(' : mutate to Misunderstanding can mutate on quantified assertion failures.', () => {
 
-		const tests = `
-		#lang forge
+        const tests = `
+        #lang forge
 
 //// Do not edit anything above this line ////
 
@@ -231,434 +231,431 @@ pred loops {
 
 assert loops is necessary for isDirectedTree
 assert all x : Node | loops is sufficient for isDirectedTree
-		  `;
-		const truncated_forge_output = `[aaa.test.frg:17:0 (span 44)] Theorem Assertion_loops_is_necessary_for_isDirectedTree failed. Found instance:
-		#(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 388) (size-clauses 555) (size-primary 20) (time-translation 98) (time-solving 8) (time-building 1708545113557)) ()) Sterling disabled, so reporting raw instance data:
-		#(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 388) (size-clauses 555) (size-primary 20) (time-translation 98) (time-solving 8) (time-building 1708545113557)) ())
-		
-		[aaa.test.frg:18:0 (span 60)] Theorem temporary-name_directedtree.test_1__Assertion_All_loops_is_sufficient_for_isDirectedTree failed. Found instance:
-		#(struct:Sat (#hash(($x_all7045 . ((Node3))) (Node . ((Node1) (Node2) (Node3))) (edges . ((Node1 Node1) (Node1 Node3) (Node2 Node2) (Node2 Node3) (Node3 Node1) (Node3 Node2))))) ((size-variables 418) (size-clauses 388) (size-primary 24) (time-translation 34) (time-solving 7) (time-building 1708545113696)) ()) Sterling disabled, so reporting raw instance data:
-		#(struct:Sat (#hash(($x_all7045 . ((Node3))) (Node . ((Node1) (Node2) (Node3))) (edges . ((Node1 Node1) (Node1 Node3) (Node2 Node2) (Node2 Node3) (Node3 Node1) (Node3 Node2))))) ((size-variables 418) (size-clauses 388) (size-primary 24) (time-translation 34) (time-solving 7) (time-building 1708545113696)) ())	`;
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+          `;
+        const truncated_forge_output = `[aaa.test.frg:17:0 (span 44)] Theorem Assertion_loops_is_necessary_for_isDirectedTree failed. Found instance:
+        #(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 388) (size-clauses 555) (size-primary 20) (time-translation 98) (time-solving 8) (time-building 1708545113557)) ()) Sterling disabled, so reporting raw instance data:
+        #(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 388) (size-clauses 555) (size-primary 20) (time-translation 98) (time-solving 8) (time-building 1708545113557)) ())
+        
+        [aaa.test.frg:18:0 (span 60)] Theorem temporary-name_directedtree.test_1__Assertion_All_loops_is_sufficient_for_isDirectedTree failed. Found instance:
+        #(struct:Sat (#hash(($x_all7045 . ((Node3))) (Node . ((Node1) (Node2) (Node3))) (edges . ((Node1 Node1) (Node1 Node3) (Node2 Node2) (Node2 Node3) (Node3 Node1) (Node3 Node2))))) ((size-variables 418) (size-clauses 388) (size-primary 24) (time-translation 34) (time-solving 7) (time-building 1708545113696)) ()) Sterling disabled, so reporting raw instance data:
+        #(struct:Sat (#hash(($x_all7045 . ((Node3))) (Node . ((Node1) (Node2) (Node3))) (edges . ((Node1 Node1) (Node1 Node3) (Node2 Node2) (Node2 Node3) (Node3 Node1) (Node3 Node2))))) ((size-variables 418) (size-clauses 388) (size-primary 24) (time-translation 34) (time-solving 7) (time-building 1708545113696)) ())    `;
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, truncated_forge_output, DIRTREE_INFO.filename, source_text);
-		let num_mutations = mutator.mutateToStudentMisunderstanding();
-
-
-
-		const expectedMutant = `#lang forge
-
-		option run_sterling off
-		
-		sig Node {edges: set Node}
-		
-		pred isDirectedTree_inner1 {
-		 edges.~edges in iden 
-		 lone edges.Node - Node.edges 
-		 no (^edges & iden) 
-		 lone Node or Node in edges.Node + Node.edges 
-		}
-		
-		pred loops {
-			 (some (^edges & iden))
-		}
-		
-		   pred isDirectedTree_inner2 { 
-			  isDirectedTree_inner1 and loops
-		   }
-		   
-		   pred isDirectedTree { 
-			all x : Node |  isDirectedTree_inner2 or loops
-		   }`;
-
-		assert.strictEqual(num_mutations, 2);
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expectedMutant));
-	});
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, truncated_forge_output, DIRTREE_INFO.filename, source_text);
+        let num_mutations = mutator.mutateToStudentMisunderstanding();
 
 
 
+        const expectedMutant = `#lang forge
 
-	it(' : mutate to Misunderstanding carries out mutations on positive examples.', () => {
+        option run_sterling off
+        
+        sig Node {edges: set Node}
+        
+        pred isDirectedTree_inner1 {
+         edges.~edges in iden 
+         lone edges.Node - Node.edges 
+         no (^edges & iden) 
+         lone Node or Node in edges.Node + Node.edges 
+        }
+        
+        pred loops {
+             (some (^edges & iden))
+        }
+        
+           pred isDirectedTree_inner2 { 
+              isDirectedTree_inner1 and loops
+           }
+           
+           pred isDirectedTree { 
+            all x : Node |  isDirectedTree_inner2 or loops
+           }`;
 
-		const tests = `
-		  
-			  #lang forge
-	
-			open "${DIRTREE_INFO.filename}"
-			//// Do not edit anything above this line ////
-		 
-		  
-		  example lasso is isDirectedTree for {
-			Node = \`Node1 + \`Node2
-			edges = \`Node1->\`Node2 + \`Node2->\`Node2
-		  }
-		  `;
-		const forge_output = `[directedtree.test.frg:13:0 (span 168)] Invalid example 'lasso'; the instance specified does not satisfy the given predicate. Sterling disabled, so reporting raw instance data:
-			#(struct:Unsat #f ((size-variables 0) (size-clauses 0) (size-primary 0) (time-translation 36) (time-solving 0) (time-building 1708545562033) (time-core 0)) unsat)
-			`;
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
-
-
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToStudentMisunderstanding();
-
-		const expected_mutant = `
-			#lang forge
-			option run_sterling off
-
-			  sig Node {edges: set Node}
-			  
-			  pred isDirectedTree_inner1 {
-					  edges.~edges in iden
-					  lone edges.Node - Node.edges 
-					  no (^edges & iden)
-					  lone Node or Node in edges.Node + Node.edges 
-			  }
-			  
-			  
-			  pred lasso {
-				  some disj Node1, Node2 : Node | {
-							  Node = Node1 + Node2
-							  edges = Node1->Node2 + Node2->Node2
-						  }
-			  }
-			  
-			  pred isDirectedTree { 
-			   isDirectedTree_inner1 or lasso
-			  }`;
-
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
-	});
+        assert.strictEqual(num_mutations, 2);
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expectedMutant));
+    });
 
 
-	it(' : mutate to Misunderstanding carries out mutations on negative examples.', () => {
-
-		const tests = `
-		  
-			  #lang forge
-	
-			open "${DIRTREE_INFO.filename}"
-			//// Do not edit anything above this line ////
-		 
-		  
-		  example line is {not isDirectedTree} for {
-			Node = \`Node1 + \`Node2
-			edges = \`Node1->\`Node2 
-		  }
-		  `;
-		const forge_output = `[directedtree.test.frg:13:0 (span 168)] Invalid example 'line'; the instance specified does not satisfy the given predicate. Sterling disabled, so reporting raw instance data:
-			#(struct:Unsat #f ((size-variables 0) (size-clauses 0) (size-primary 0) (time-translation 36) (time-solving 0) (time-building 1708545562033) (time-core 0)) unsat)
-			`;
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
 
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToStudentMisunderstanding();
+    it(' : mutate to Misunderstanding carries out mutations on positive examples.', () => {
 
-		const expected_mutant = `
-			#lang forge
-			option run_sterling off
-
-			  sig Node {edges: set Node}
-			  
-			  pred isDirectedTree_inner1 {
-					  edges.~edges in iden
-					  lone edges.Node - Node.edges 
-					  no (^edges & iden)
-					  lone Node or Node in edges.Node + Node.edges 
-			  }
-			  
-			  
-			  pred line {
-				  some disj Node1, Node2 : Node | {
-							  Node = Node1 + Node2
-							  edges = Node1->Node2
-						  }
-			  }
-			  
-			  pred isDirectedTree { 
-			   isDirectedTree_inner1 and not line
-			  }`;
-
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
-	});
-
-	it(' : mutate to Misunderstanding carries out mutations on examples and assertions when combined.', () => {
-
-		const tests = `
-		  
-			  #lang forge
-	
-			open "${DIRTREE_INFO.filename}"
-			//// Do not edit anything above this line ////
-		 
-			pred mustBeEmpty {
-				no edges
-		    }
-		   
-		   assert mustBeEmpty is necessary for isDirectedTree
-		  
-		  example loop is {isDirectedTree} for {
-			Node = \`Node1 + \`Node2
-			edges = \`Node1->\`Node2  + \`Node2->\`Node1
-		  }
-		  `;
-		const forge_output = `[directedtree.test.frg:21:19 (span 50)] Theorem Assertion_mustBeEmpty_is_necessary_for_isDirectedTree failed. Found instance:
-			#(struct:Sat (#hash((Node . ((Node2) (Node3))) (edges . ((Node3 Node2))))) ((size-variables 390) (size-clauses 558) (size-primary 20) (time-translation 77) (time-solving 9) (time-building 1708555673207)) ()) Sterling disabled, so reporting raw instance data:
-			#(struct:Sat (#hash((Node . ((Node2) (Node3))) (edges . ((Node3 Node2))))) ((size-variables 390) (size-clauses 558) (size-primary 20) (time-translation 77) (time-solving 9) (time-building 1708555673207)) ())
-			
-			[directedtree.test.frg:23:18 (span 114)] Invalid example 'loop'; the instance specified does not satisfy the given predicate. Sterling disabled, so reporting raw instance data:
-			#(struct:Unsat #f ((size-variables 0) (size-clauses 0) (size-primary 0) (time-translation 5) (time-solving 0) (time-building 1708555673326) (time-core 0)) unsat)			
-			`;
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+        const tests = `
+          
+              #lang forge
+    
+            open "${DIRTREE_INFO.filename}"
+            //// Do not edit anything above this line ////
+         
+          
+          example lasso is isDirectedTree for {
+            Node = \`Node1 + \`Node2
+            edges = \`Node1->\`Node2 + \`Node2->\`Node2
+          }
+          `;
+        const forge_output = `[directedtree.test.frg:13:0 (span 168)] Invalid example 'lasso'; the instance specified does not satisfy the given predicate. Sterling disabled, so reporting raw instance data:
+            #(struct:Unsat #f ((size-variables 0) (size-clauses 0) (size-primary 0) (time-translation 36) (time-solving 0) (time-building 1708545562033) (time-core 0)) unsat)
+            `;
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
 
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToStudentMisunderstanding();
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToStudentMisunderstanding();
 
-		const expected_mutant = `#lang forge
+        const expected_mutant = `
+            #lang forge
+            option run_sterling off
 
-			  option run_sterling off
-			  
-			  sig Node {edges: set Node}
-			  
-			  pred isDirectedTree_inner1 {
-				edges.~edges in iden 
-				lone edges.Node - Node.edges 
-				no (^edges & iden) 
-				lone Node or Node in edges.Node + Node.edges 
-			  }
-			  
-			  pred mustBeEmpty {
-					  no edges
-			  }
-			  
-			  pred isDirectedTree_inner2 { 
-				  isDirectedTree_inner1 and mustBeEmpty
-			  }
-					
-			  pred loop {
-				  some disj Node1, Node2 : Node | {
-					  Node = Node1 + Node2
-					  edges = Node1->Node2  + Node2->Node1
-				  }
-			  }
-			  
-			  pred isDirectedTree { 
-				  isDirectedTree_inner2 or loop
-			  }`;
+              sig Node {edges: set Node}
+              
+              pred isDirectedTree_inner1 {
+                      edges.~edges in iden
+                      lone edges.Node - Node.edges 
+                      no (^edges & iden)
+                      lone Node or Node in edges.Node + Node.edges 
+              }
+              
+              
+              pred lasso {
+                  some disj Node1, Node2 : Node | {
+                              Node = Node1 + Node2
+                              edges = Node1->Node2 + Node2->Node2
+                          }
+              }
+              
+              pred isDirectedTree { 
+               isDirectedTree_inner1 or lasso
+              }`;
 
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
-	});
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+    });
+
+
+    it(' : mutate to Misunderstanding carries out mutations on negative examples.', () => {
+
+        const tests = `
+          
+              #lang forge
+    
+            open "${DIRTREE_INFO.filename}"
+            //// Do not edit anything above this line ////
+         
+          
+          example line is {not isDirectedTree} for {
+            Node = \`Node1 + \`Node2
+            edges = \`Node1->\`Node2 
+          }
+          `;
+        const forge_output = `[directedtree.test.frg:13:0 (span 168)] Invalid example 'line'; the instance specified does not satisfy the given predicate. Sterling disabled, so reporting raw instance data:
+            #(struct:Unsat #f ((size-variables 0) (size-clauses 0) (size-primary 0) (time-translation 36) (time-solving 0) (time-building 1708545562033) (time-core 0)) unsat)
+            `;
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+
+
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToStudentMisunderstanding();
+
+        const expected_mutant = `
+            #lang forge
+            option run_sterling off
+
+              sig Node {edges: set Node}
+              
+              pred isDirectedTree_inner1 {
+                      edges.~edges in iden
+                      lone edges.Node - Node.edges 
+                      no (^edges & iden)
+                      lone Node or Node in edges.Node + Node.edges 
+              }
+              
+              
+              pred line {
+                  some disj Node1, Node2 : Node | {
+                              Node = Node1 + Node2
+                              edges = Node1->Node2
+                          }
+              }
+              
+              pred isDirectedTree { 
+               isDirectedTree_inner1 and not line
+              }`;
+
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+    });
+
+    it(' : mutate to Misunderstanding carries out mutations on examples and assertions when combined.', () => {
+
+        const tests = `
+          
+              #lang forge
+    
+            open "${DIRTREE_INFO.filename}"
+            //// Do not edit anything above this line ////
+         
+            pred mustBeEmpty {
+                no edges
+            }
+           
+           assert mustBeEmpty is necessary for isDirectedTree
+          
+          example loop is {isDirectedTree} for {
+            Node = \`Node1 + \`Node2
+            edges = \`Node1->\`Node2  + \`Node2->\`Node1
+          }
+          `;
+        const forge_output = `[directedtree.test.frg:21:19 (span 50)] Theorem Assertion_mustBeEmpty_is_necessary_for_isDirectedTree failed. Found instance:
+            #(struct:Sat (#hash((Node . ((Node2) (Node3))) (edges . ((Node3 Node2))))) ((size-variables 390) (size-clauses 558) (size-primary 20) (time-translation 77) (time-solving 9) (time-building 1708555673207)) ()) Sterling disabled, so reporting raw instance data:
+            #(struct:Sat (#hash((Node . ((Node2) (Node3))) (edges . ((Node3 Node2))))) ((size-variables 390) (size-clauses 558) (size-primary 20) (time-translation 77) (time-solving 9) (time-building 1708555673207)) ())
+            
+            [directedtree.test.frg:23:18 (span 114)] Invalid example 'loop'; the instance specified does not satisfy the given predicate. Sterling disabled, so reporting raw instance data:
+            #(struct:Unsat #f ((size-variables 0) (size-clauses 0) (size-primary 0) (time-translation 5) (time-solving 0) (time-building 1708555673326) (time-core 0)) unsat)            
+            `;
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+
+
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToStudentMisunderstanding();
+
+        const expected_mutant = `#lang forge
+
+              option run_sterling off
+              
+              sig Node {edges: set Node}
+              
+              pred isDirectedTree_inner1 {
+                edges.~edges in iden 
+                lone edges.Node - Node.edges 
+                no (^edges & iden) 
+                lone Node or Node in edges.Node + Node.edges 
+              }
+              
+              pred mustBeEmpty {
+                      no edges
+              }
+              
+              pred isDirectedTree_inner2 { 
+                  isDirectedTree_inner1 and mustBeEmpty
+              }
+                    
+              pred loop {
+                  some disj Node1, Node2 : Node | {
+                      Node = Node1 + Node2
+                      edges = Node1->Node2  + Node2->Node1
+                  }
+              }
+              
+              pred isDirectedTree { 
+                  isDirectedTree_inner2 or loop
+              }`;
+
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+    });
 });
 
 
 
 describe('Mutator to Understanding', () => {
 
-	it(' : mutate to Understanding carries out no mutations if not in test suites.', () => {
+    it(' : mutate to Understanding carries out no mutations if not in test suites.', () => {
 
-		const tests = `
-		  
-			  #lang forge
-	
-			open "${DIRTREE_INFO.filename}"
+        const tests = `
+          
+              #lang forge
+    
+            open "${DIRTREE_INFO.filename}"
 //// Do not edit anything above this line ////
-		 
-				example e1 is isDirectedTree for {
-					Node = \`Node1 + \`Node2
-					edges = \`Node1->\`Node2
-				}
+         
+                example e1 is isDirectedTree for {
+                    Node = \`Node1 + \`Node2
+                    edges = \`Node1->\`Node2
+                }
 
-				example e2 is isDirectedTree for {
-					Node = \`Node1 + \`Node2 + \`Node3
-					edges = \`Node2->\`Node1 + \`Node2->\`Node3
-				}
-		  `;
-		const forge_output = "";
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+                example e2 is isDirectedTree for {
+                    Node = \`Node1 + \`Node2 + \`Node3
+                    edges = \`Node2->\`Node1 + \`Node2->\`Node3
+                }
+          `;
+        const forge_output = "";
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToPositiveTests();
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToPositiveTests();
 
-		const expected_mutant = `#lang forge`
+        const expected_mutant = `#lang forge`
 
-		assert.strictEqual(mutator.num_mutations, 0);
-	});
+        assert.strictEqual(mutator.num_mutations, 0);
+    });
 
 
-	it(' : mutate to positive examples carries mutations on examples.', () => {
+    it(' : mutate to positive examples carries mutations on examples.', () => {
 
-		const tests = `
-		  
-			  #lang forge
-	
-			open "${DIRTREE_INFO.filename}"
-			//// Do not edit anything above this line ////
-		 
-			test suite for isDirectedTree {
-				example e1 is isDirectedTree for {
-					Node = \`Node1 + \`Node2
-					edges = \`Node1->\`Node2
-				}
+        const tests = `
+          
+              #lang forge
+    
+            open "${DIRTREE_INFO.filename}"
+            //// Do not edit anything above this line ////
+         
+            test suite for isDirectedTree {
+                example e1 is isDirectedTree for {
+                    Node = \`Node1 + \`Node2
+                    edges = \`Node1->\`Node2
+                }
 
-				example e2 is isDirectedTree for {
-					Node = \`Node1 + \`Node2 + \`Node3
-					edges = \`Node2->\`Node1 + \`Node2->\`Node3
-				}
-			}
-		  `;
-		const forge_output = "";
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+                example e2 is isDirectedTree for {
+                    Node = \`Node1 + \`Node2 + \`Node3
+                    edges = \`Node2->\`Node1 + \`Node2->\`Node3
+                }
+            }
+          `;
+        const forge_output = "";
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToPositiveTests();
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToPositiveTests();
 
-		const expected_mutant = `
-			#lang forge
+        const expected_mutant = `
+            #lang forge
 
-			option run_sterling off
+            option run_sterling off
 
-			sig Node {edges: set Node}
+            sig Node {edges: set Node}
 
-			pred isDirectedTree_inner1 {
-					edges.~edges in iden
-					lone edges.Node - Node.edges 
-					no (^edges & iden)
-					lone Node or Node in edges.Node + Node.edges 
-			}
+            pred isDirectedTree_inner1 {
+                    edges.~edges in iden
+                    lone edges.Node - Node.edges 
+                    no (^edges & iden)
+                    lone Node or Node in edges.Node + Node.edges 
+            }
 
-			pred e1 {
-				some disj Node1, Node2 : Node | {
-						Node = Node1 + Node2
-						edges = Node1->Node2
-						}
-				}
+            pred e1 {
+                some disj Node1, Node2 : Node | {
+                        Node = Node1 + Node2
+                        edges = Node1->Node2
+                        }
+                }
         
-			pred e2 {
-				some disj Node1, Node2, Node3 : Node | {
-					Node = Node1 + Node2 + Node3
-					edges = Node2->Node1 + Node2->Node3
-					}
-			}
+            pred e2 {
+                some disj Node1, Node2, Node3 : Node | {
+                    Node = Node1 + Node2 + Node3
+                    edges = Node2->Node1 + Node2->Node3
+                    }
+            }
 
-			pred isDirectedTree_inner2 { 
-						isDirectedTree_inner1 and not e1
-			}
+            pred isDirectedTree_inner2 { 
+                        isDirectedTree_inner1 and not e1
+            }
 
-			pred isDirectedTree { 
-						isDirectedTree_inner2 and not e2
-			}
-			`;
+            pred isDirectedTree { 
+                        isDirectedTree_inner2 and not e2
+            }
+            `;
 
-		assert.strictEqual(mutator.num_mutations, 2);
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
-	});
-
-
-	it(' : mutate to negative tests carries out mutations on assertions.', () => {
-
-		const tests = `
-		  
-			  #lang forge
-	
-			open "${DIRTREE_INFO.filename}"
-			//// Do not edit anything above this line ////
-		 
-
-			pred a1 {
-				no (^edges & iden)
-			}
-
-			pred a2 {
-				edges.~edges in iden 
-			}
+        assert.strictEqual(mutator.num_mutations, 2);
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+    });
 
 
-			test suite for isDirectedTree {
-				assert a1 is necessary for isDirectedTree
-				assert isDirectedTree is sufficient for a2
-			}
-		  `;
-		const forge_output = "";
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+    it(' : mutate to negative tests carries out mutations on assertions.', () => {
 
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToNegativeTests();
+        const tests = `
+          
+              #lang forge
+    
+            open "${DIRTREE_INFO.filename}"
+            //// Do not edit anything above this line ////
+         
 
-		const expected_mutant = `
-			#lang forge
+            pred a1 {
+                no (^edges & iden)
+            }
 
-			option run_sterling off
-	
-			sig Node {edges: set Node}
-	
-			pred isDirectedTree_inner1 { }
-	
-	pred a1 {
-			no (^edges & iden)
-	}
-	pred a2 {
-			edges.~edges in iden 
-	}
-	
-	pred isDirectedTree_inner2 { 
-			 isDirectedTree_inner1 and a1
-	}
-	
-	pred isDirectedTree { 
-			 isDirectedTree_inner2 and  a2
-	}
-			`;
-
-		assert.strictEqual(mutator.num_mutations, 2);
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
-	});
+            pred a2 {
+                edges.~edges in iden 
+            }
 
 
-	it(' : mutate to positive tests carries out mutations on negative examples.', () => {
+            test suite for isDirectedTree {
+                assert a1 is necessary for isDirectedTree
+                assert isDirectedTree is sufficient for a2
+            }
+          `;
+        const forge_output = "";
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-		const tests = `
-		  
-			#lang forge
-	
-			open "${DIRTREE_INFO.filename}"
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToNegativeTests();
+
+        const expected_mutant = `
+            #lang forge
+
+            option run_sterling off
+    
+            sig Node {edges: set Node}
+    
+            pred isDirectedTree_inner1 { }
+    
+    pred a1 {
+            no (^edges & iden)
+    }
+    pred a2 {
+            edges.~edges in iden 
+    }
+    
+    pred isDirectedTree_inner2 { 
+             isDirectedTree_inner1 and a1
+    }
+    
+    pred isDirectedTree { 
+             isDirectedTree_inner2 and  a2
+    }
+            `;
+
+        assert.strictEqual(mutator.num_mutations, 2);
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+    });
+
+
+    it(' : mutate to negative tests carries out mutations on negative examples.', () => {
+
+        const tests = `
+          
+            #lang forge
+    
+            open "${DIRTREE_INFO.filename}"
 //// Do not edit anything above this line ////
-		 
-		  test suite for isDirectedTree {
-			example lasso is !isDirectedTree for {
-				Node = \`Node1 + \`Node2
-				edges = \`Node1->\`Node2 + \`Node2->\`Node2
-			}
+         
+          test suite for isDirectedTree {
+            example lasso is !isDirectedTree for {
+                Node = \`Node1 + \`Node2
+                edges = \`Node1->\`Node2 + \`Node2->\`Node2
+            }
 
-			example loop is {not isDirectedTree} for {
-				Node = \`Node1 + \`Node2
-				edges = \`Node1->\`Node2  + \`Node2->\`Node1
-			}
-		}
-		  `;
-		const forge_output = ``;
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
-
-
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToPositiveTests();
+            example loop is {not isDirectedTree} for {
+                Node = \`Node1 + \`Node2
+                edges = \`Node1->\`Node2  + \`Node2->\`Node1
+            }
+        }
+          `;
+        const forge_output = ``;
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
 
-		const expected_mutant = `
-			                  
-#lang forge
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToNegativeTests();
 
-option run_sterling off
 
-sig Node {edges: set Node}
 
-pred isDirectedTree_inner1 {
-        edges.~edges in iden
-        lone edges.Node - Node.edges 
-        no (^edges & iden)
-        lone Node or Node in edges.Node + Node.edges 
-}
+        const expected_mutant = `
+                              
+        #lang forge
+
+        option run_sterling off
+
+        sig Node {edges: set Node}
+
+        pred isDirectedTree_inner1 {}
+
 
 pred lasso {
 some disj Node1, Node2 : Node | {
@@ -670,6 +667,11 @@ edges = Node1->Node2 + Node2->Node2
 }
 
 }
+
+pred isDirectedTree_inner2 { 
+         isDirectedTree_inner1 and not lasso
+}
+
 pred loop {
 some disj Node1, Node2 : Node | {
 
@@ -680,55 +682,52 @@ edges = Node1->Node2  + Node2->Node1
 }
 
 }
-pred isDirectedTree_inner2 { 
- isDirectedTree_inner1 or lasso
-}
 
 pred isDirectedTree { 
- isDirectedTree_inner2 or loop
+         isDirectedTree_inner2 and not loop
 }`;
-		assert.strictEqual(mutator.num_mutations, 2);
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
-	});
+        assert.strictEqual(mutator.num_mutations, 2);
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+    });
 
 
 
-	it(' : mutate to positive test carries mutations on quantified assertions only if they are positive.', () => {
+    it(' : mutate to positive test carries mutations on quantified assertions only if they are positive.', () => {
 
-		const tests = `
-		  
-			  #lang forge
-	
-			open "${DIRTREE_INFO.filename}"
-			//// Do not edit anything above this line ////
-		 
-			// sufficient
-			pred a1[r : Node] {
-				one Node
-				r->r not in edges
-			}
+        const tests = `
+          
+              #lang forge
+    
+            open "${DIRTREE_INFO.filename}"
+            //// Do not edit anything above this line ////
+         
+            // sufficient
+            pred a1[r : Node] {
+                one Node
+                r->r not in edges
+            }
 
-			// necessary
-			pred a2[n : Node] {
-				n not in (^edges & iden)
-			}
-
-
-			test suite for isDirectedTree {
-				assert all x : Node | a1[x] is sufficient for isDirectedTree
-				assert all x : Node | a2[x] is necessary for isDirectedTree
-			}
-		  `;
-		const forge_output = "";
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
-
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToPositiveTests();
+            // necessary
+            pred a2[n : Node] {
+                n not in (^edges & iden)
+            }
 
 
+            test suite for isDirectedTree {
+                assert all x : Node | a1[x] is sufficient for isDirectedTree
+                assert all x : Node | a2[x] is necessary for isDirectedTree
+            }
+          `;
+        const forge_output = "";
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-		const expected_mutant = `
-			#lang forge
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToPositiveTests();
+
+        
+
+        const expected_mutant = `
+            #lang forge
 
 option run_sterling off
 
@@ -751,163 +750,151 @@ pred a2[n : Node] {
 
 
 pred isDirectedTree { 
-	isDirectedTree_inner1 and not (all x : Node | a1[x] => isDirectedTree_inner1)
+    isDirectedTree_inner1 and not (all x : Node | a1[x] => isDirectedTree_inner1)
 }
-			`;
+            `;
 
-		assert.strictEqual(mutator.num_mutations, 1);
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
-	});
-
-
-	it(' : mutate to negative test carries mutations on quantified assertions only if they are negative.', () => {
-
-		const tests = `
-		  
-			  #lang forge
-	
-			open "${DIRTREE_INFO.filename}"
-			//// Do not edit anything above this line ////
-		 
-			// sufficient
-			pred a1[r : Node] {
-				one Node
-				r->r not in edges
-			}
-
-			// necessary
-			pred a2[n : Node] {
-				n not in (^edges & iden)
-			}
+        assert.strictEqual(mutator.num_mutations, 1);
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+    });
 
 
-			test suite for isDirectedTree {
-				assert all x : Node | a1[x] is sufficient for isDirectedTree
-				assert all x : Node | a2[x] is necessary for isDirectedTree
-			}
-		  `;
-		const forge_output = "";
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+    it(' : mutate to negative test carries mutations on quantified assertions only if they are negative.', () => {
 
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToNegativeTests();
+        const tests = `
+          
+              #lang forge
+    
+            open "${DIRTREE_INFO.filename}"
+            //// Do not edit anything above this line ////
+         
+            // sufficient
+            pred a1[r : Node] {
+                one Node
+                r->r not in edges
+            }
 
-		console.log(mutator.mutant)
+            // necessary
+            pred a2[n : Node] {
+                n not in (^edges & iden)
+            }
 
-		const expected_mutant = `
-		#lang forge
 
-		option run_sterling off
+            test suite for isDirectedTree {
+                assert all x : Node | a1[x] is sufficient for isDirectedTree
+                assert all x : Node | a2[x] is necessary for isDirectedTree
+            }
+          `;
+        const forge_output = "";
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-		sig Node {edges: set Node}
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToNegativeTests();
 
-		pred isDirectedTree_inner1 {}
+
+
+        const expected_mutant = `
+        #lang forge
+
+        option run_sterling off
+
+        sig Node {edges: set Node}
+
+        pred isDirectedTree_inner1 {}
 
 pred a1[r : Node] {
-		one Node
-		r->r not in edges
+        one Node
+        r->r not in edges
 }
 pred a2[n : Node] {
-		n not in (^edges & iden)
+        n not in (^edges & iden)
 }
 
 pred isDirectedTree { 
-		 all x : Node | isDirectedTree_inner1 and a2[x]
+         all x : Node | isDirectedTree_inner1 and a2[x]
 }
-			`;
+            `;
 
-		assert.strictEqual(mutator.num_mutations, 1);
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
-	});
-
-
-	it(' : mutate to positive test carries mutations out when tests are of various types, but ignores negative tests.', () => {
-
-		const tests = `
-		  
-			  #lang forge
-	
-			open "${DIRTREE_INFO.filename}"
-			//// Do not edit anything above this line ////
-		 
-			// sufficient
-			pred a1[r : Node] {
-				one Node
-				r->r not in edges
-			}
-
-			pred a2 {
-				edges.~edges in iden 
-			}
-
-			example willBeIgnored is isDirectedTree for {
-				Node = \`Node1
-				no edges
-			}
-
-			test suite for isDirectedTree {
-				assert all x : Node | a1[x] is sufficient for isDirectedTree
-				assert a2 is necessary for isDirectedTree
+        assert.strictEqual(mutator.num_mutations, 1);
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+    });
 
 
-				example lasso is !isDirectedTree for {
-					Node = \`Node1 + \`Node2
-					edges = \`Node1->\`Node2 + \`Node2->\`Node2
-				}
+    it(' : mutate to positive test carries mutations out when tests are of various types, but ignores negative tests.', () => {
+
+        const tests = `
+          
+              #lang forge
+    
+            open "${DIRTREE_INFO.filename}"
+            //// Do not edit anything above this line ////
+         
+            // sufficient
+            pred a1[r : Node] {
+                one Node
+                r->r not in edges
+            }
+
+            pred a2 {
+                edges.~edges in iden 
+            }
+
+            example willBeIgnored is isDirectedTree for {
+                Node = \`Node1
+                no edges
+            }
+
+            test suite for isDirectedTree {
+                assert all x : Node | a1[x] is sufficient for isDirectedTree
+                assert a2 is necessary for isDirectedTree
 
 
-			}
-		  `;
-		const forge_output = "";
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
-
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToPositiveTests();
+                example lasso is !isDirectedTree for {
+                    Node = \`Node1 + \`Node2
+                    edges = \`Node1->\`Node2 + \`Node2->\`Node2
+                }
 
 
-		const expected_mutant = `#lang forge
+            }
+          `;
+        const forge_output = "";
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-		option run_sterling off
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToPositiveTests();
+            console.log(mutator.mutant);
+            
+        const expected_mutant = `
+        #lang forge
 
-		sig Node {edges: set Node}
+                                option run_sterling off
 
-		pred isDirectedTree_inner1 {
-				edges.~edges in iden
-				lone edges.Node - Node.edges 
-				no (^edges & iden)
-				lone Node or Node in edges.Node + Node.edges 
-		}
+                                sig Node {edges: set Node}
+
+                                pred isDirectedTree_inner1 {
+                                        edges.~edges in iden
+                                        lone edges.Node - Node.edges 
+                                        no (^edges & iden)
+                                        lone Node or Node in edges.Node + Node.edges 
+                                }
 
 pred a1[r : Node] {
-		one Node
-		r->r not in edges
-}
+                                one Node
+                                r->r not in edges
+                        }
 pred a2 {
-		edges.~edges in iden 
-}
-pred lasso {
-some disj Node1, Node2 : Node | {
+                                edges.~edges in iden 
+                        }
 
+		pred isDirectedTree { 
+					isDirectedTree_inner1 and not (all x : Node | a1[x] => isDirectedTree_inner1)
+		}
 
-Node = Node1 + Node2
-edges = Node1->Node2 + Node2->Node2
+            `;
 
-}
-
-}
-pred isDirectedTree_inner2 { 
-		 isDirectedTree_inner1 or lasso
-}
-
-pred isDirectedTree { 
-		 isDirectedTree_inner2 and not (all x : Node | a1[x] => isDirectedTree_inner2)
-}
-
-			`;
-
-		assert.strictEqual(mutator.num_mutations, 2);
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
-	});
+        assert.strictEqual(mutator.num_mutations, 1);
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+    });
 
 
 });

--- a/package.json
+++ b/package.json
@@ -84,11 +84,16 @@
 					"default": "Comprehensive",
 					"description": "Feedback strategy used by Toadus Ponens. Comprehensive will provide feedback for the test suite as a whole, Per Test will provide feedback for each test."
 				},
-				"forge.thoroughnessFeedbackEnabled": {
+				"forge.thoroughnessFeedback": {
 					"scope": "resource",
-					"type": "boolean",
-					"default": true,
-					"description": "Determines if the experimental Toadus Ponens test feedback feature is enabled"
+					"type": "string",
+					"enum": [
+						"Off",
+						"Partial",
+						"Full"
+					],
+					"default": "Partial",
+					"description": "Determines the level of thoroughness feedback given by Toadus Ponens. Full offers more accurate thoroughness feedback, but is experimental and may be buggy."
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"description": "Forge Language Server",
 	"author": "",
 	"license": "",
-	"version": "2.3.2",
+	"version": "2.3.3",
 	"repository": {
 		"type": "git",
 		"url": ""


### PR DESCRIPTION
There is an issue with the current mutation stratgey, which works only when all tests are positive.

This change segregates tests into positive and negative tests. Then, for positive tests, it removes any tests in the intersection of the property and the predicate and run against the autograder to generate hints (passing = hint)
For negative tests, I build student predicates from scratch using their necessary assertions. I run the autograder against this (fail = hint).
Finally, we serve hints from the intersection of the two (ie - not caught by the +ve mutation or the negative mutation)


