### PR TITLE
Multifaceted mutation (#24)

### DIFF
--- a/client/src/test/mutator.tests.ts
+++ b/client/src/test/mutator.tests.ts
@@ -4,225 +4,224 @@ import { strict as assert, strictEqual } from 'assert';
 
 // TODO: This is duplicated, find a better place to put it.
 export function combineTestsWithModel(wheatText: string, tests: string): string {
-	const TEST_SEPARATOR = "//// Do not edit anything above this line ////"
-	const hashlang_decl = "#lang";
+    const TEST_SEPARATOR = "//// Do not edit anything above this line ////"
+    const hashlang_decl = "#lang";
 
-	if (tests.includes(TEST_SEPARATOR)) {
-		const startIndex = tests.indexOf(TEST_SEPARATOR) + TEST_SEPARATOR.length;
-		tests = tests.substring(startIndex).trim();
-	}
+    if (tests.includes(TEST_SEPARATOR)) {
+        const startIndex = tests.indexOf(TEST_SEPARATOR) + TEST_SEPARATOR.length;
+        tests = tests.substring(startIndex).trim();
+    }
+    tests = tests.replace(hashlang_decl, "// #lang");
 
-	tests = tests.replace(hashlang_decl, "// #lang");
+    var combined = wheatText + "\n" + tests;
+    combined = removeForgeComments(combined);
 
-	var combined = wheatText + "\n" + tests;
-	combined = removeForgeComments(combined);
-
-	return combined;
+    return combined;
 
 }
 
 function removeWhitespace(str: string): string {
-	return str.replace(/\s/g, '');
+    return str.replace(/\s/g, '');
 }
 
 
 const DIRTREE_INFO = {
 
-	wheat: `#lang forge
+    wheat: `#lang forge
 
-				option run_sterling off
+                option run_sterling off
 
-				sig Node {edges: set Node}
+                sig Node {edges: set Node}
 
-				pred isDirectedTree {
-					edges.~edges in iden
-					lone edges.Node - Node.edges 
-					no (^edges & iden)
-					lone Node or Node in edges.Node + Node.edges 
-				}`,
-	filename: "dirTree.frg",
+                pred isDirectedTree {
+                    edges.~edges in iden
+                    lone edges.Node - Node.edges 
+                    no (^edges & iden)
+                    lone Node or Node in edges.Node + Node.edges 
+                }`,
+    filename: "dirTree.frg",
 }
 
 
 
 
 // mutator constructor(wheat: string, student_tests: string, forge_output: string, test_file_name: string, source_text : string) {
-describe('Mutator', () => {
-	it(' : mutate to Misunderstanding carries out no mutations if there are no wheat failures.', () => {
+describe('Mutator to Misunderstanding', () => {
+    it(' : mutate to Misunderstanding carries out no mutations if there are no wheat failures.', () => {
 
-		const tests = `
-	  
-	  	#lang forge
+        const tests = `
+      
+          #lang forge
 
-		open "${DIRTREE_INFO.filename}"
-		//// Do not edit anything above this line ////
-	 
-	  test expect {
-		injective : {isDirectedTree implies (edges.~edges in iden)} is theorem
-		injective_insufficient : {(edges.~edges in iden) and !isDirectedTree} is sat
-	  
-		root : {isDirectedTree implies (lone edges.Node - Node.edges) } is theorem
-		loopless : {isDirectedTree implies (no (^edges & iden))} is theorem
-		connected : {isDirectedTree implies (lone Node or Node in edges.Node + Node.edges) } is theorem
-	  }
-	  
-	  example twoNodeTree is isDirectedTree for {
-		Node = \`Node1 + \`Node2
-		edges = \`Node1->\`Node2
-	  }
-	  `;
-		const forge_output = "";
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+        open "${DIRTREE_INFO.filename}"
+        //// Do not edit anything above this line ////
+     
+      test expect {
+        injective : {isDirectedTree implies (edges.~edges in iden)} is theorem
+        injective_insufficient : {(edges.~edges in iden) and !isDirectedTree} is sat
+      
+        root : {isDirectedTree implies (lone edges.Node - Node.edges) } is theorem
+        loopless : {isDirectedTree implies (no (^edges & iden))} is theorem
+        connected : {isDirectedTree implies (lone Node or Node in edges.Node + Node.edges) } is theorem
+      }
+      
+      example twoNodeTree is isDirectedTree for {
+        Node = \`Node1 + \`Node2
+        edges = \`Node1->\`Node2
+      }
+      `;
+        const forge_output = "";
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToStudentMisunderstanding();
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(DIRTREE_INFO.wheat));
-	});
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToStudentMisunderstanding();
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(DIRTREE_INFO.wheat));
+    });
 
 
 
-	it(' : mutate to Misunderstanding ignores test expects for mutations.', () => {
+    it(' : mutate to Misunderstanding ignores test expects for mutations.', () => {
 
-		const tests = `
-		
-			#lang forge
+        const tests = `
+        
+            #lang forge
   
-		  open "${DIRTREE_INFO.filename}"
-		  //// Do not edit anything above this line ////
-	   
-		test expect {
-		  contradiction : {isDirectedTree and !isDirectedTree } is sat
-		}`;
-		const forge_output = "";
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+          open "${DIRTREE_INFO.filename}"
+          //// Do not edit anything above this line ////
+       
+        test expect {
+          contradiction : {isDirectedTree and !isDirectedTree } is sat
+        }`;
+        const forge_output = "";
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToStudentMisunderstanding();
-
-
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(DIRTREE_INFO.wheat));
-	});
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToStudentMisunderstanding();
 
 
-	it(' : mutate to Misunderstanding ignores examples that do not directly reference a predicate.', () => {
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(DIRTREE_INFO.wheat));
+    });
 
-		const tests = `
-	  
-	  	#lang forge
 
-		open "${DIRTREE_INFO.filename}"
-		//// Do not edit anything above this line ////
-	 
+    it(' : mutate to Misunderstanding ignores examples that do not directly reference a predicate.', () => {
 
-	  
-	  example someexamplename1 is {all t : Node | isDirectedTree } for {
-		Node = \`Node1 + \`Node2
-		no edges
-	  }
+        const tests = `
+      
+          #lang forge
 
-	  pred anotherPred {
-		  some edges
-	  }
+        open "${DIRTREE_INFO.filename}"
+        //// Do not edit anything above this line ////
+     
 
-	  example someexamplename2 is anotherPred for {
-		Node = \`Node1 
-		no edges
-	  }
+      
+      example someexamplename1 is {all t : Node | isDirectedTree } for {
+        Node = \`Node1 + \`Node2
+        no edges
+      }
 
-	  `;
-		const forge_output = "";
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+      pred anotherPred {
+          some edges
+      }
 
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToStudentMisunderstanding();
-		assert.strictEqual(mutator.num_mutations, 0);
+      example someexamplename2 is anotherPred for {
+        Node = \`Node1 
+        no edges
+      }
 
-		let outputs = mutator.error_messages;
+      `;
+        const forge_output = "";
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-		for (let output of outputs) {
-			assert.strict(output.includes('someexamplename1') || output.includes('someexamplename'));
-		}
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToStudentMisunderstanding();
+        assert.strictEqual(mutator.num_mutations, 0);
 
-	});
+        let outputs = mutator.error_messages;
 
-	it(' : mutate to Misunderstanding can mutate on multiple assertion failures.', () => {
+        for (let output of outputs) {
+            assert.strict(output.includes('someexamplename1') || output.includes('someexamplename'));
+        }
 
-		const tests = `
-		
-			#lang forge
+    });
+
+    it(' : mutate to Misunderstanding can mutate on multiple assertion failures.', () => {
+
+        const tests = `
+        
+            #lang forge
   
-		  open "${DIRTREE_INFO.filename}"
-		  //// Do not edit anything above this line ////
-	   
+          open "${DIRTREE_INFO.filename}"
+          //// Do not edit anything above this line ////
+       
 
-		  pred loops {
+          pred loops {
     
-			(some (^edges & iden))
-			}
-	   
-	   assert loops is necessary for isDirectedTree
-	   
-	   
-	   pred mustHaveRoot {
-	   
-		   one edges.Node - Node.edges
-	   }
-	   
-	   assert mustHaveRoot is necessary for isDirectedTree
-		  `;
-		const forge_output = `[hQNVMlZUHG.rkt:18:0 (span 44)] Theorem Assertion_loops_is_necessary_for_isDirectedTree failed. Found instance:
-		#(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 388) (size-clauses 555) (size-primary 20) (time-translation 90) (time-solving 9) (time-building 1708532242901)) ()) Sterling disabled, so reporting raw instance data:
-		#(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 388) (size-clauses 555) (size-primary 20) (time-translation 90) (time-solving 9) (time-building 1708532242901)) ())
-		
-		[hQNVMlZUHG.rkt:26:0 (span 51)] Theorem Assertion_mustHaveRoot_is_necessary_for_isDirectedTree failed. Found instance:
-		#(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 390) (size-clauses 604) (size-primary 20) (time-translation 27) (time-solving 6) (time-building 1708532243034)) ()) Sterling disabled, so reporting raw instance data:
-		#(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 390) (size-clauses 604) (size-primary 20) (time-translation 27) (time-solving 6) (time-building 1708532243034)) ())
+            (some (^edges & iden))
+            }
+       
+       assert loops is necessary for isDirectedTree
+       
+       
+       pred mustHaveRoot {
+       
+           one edges.Node - Node.edges
+       }
+       
+       assert mustHaveRoot is necessary for isDirectedTree
+          `;
+        const forge_output = `[hQNVMlZUHG.rkt:18:0 (span 44)] Theorem Assertion_loops_is_necessary_for_isDirectedTree failed. Found instance:
+        #(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 388) (size-clauses 555) (size-primary 20) (time-translation 90) (time-solving 9) (time-building 1708532242901)) ()) Sterling disabled, so reporting raw instance data:
+        #(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 388) (size-clauses 555) (size-primary 20) (time-translation 90) (time-solving 9) (time-building 1708532242901)) ())
+        
+        [hQNVMlZUHG.rkt:26:0 (span 51)] Theorem Assertion_mustHaveRoot_is_necessary_for_isDirectedTree failed. Found instance:
+        #(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 390) (size-clauses 604) (size-primary 20) (time-translation 27) (time-solving 6) (time-building 1708532243034)) ()) Sterling disabled, so reporting raw instance data:
+        #(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 390) (size-clauses 604) (size-primary 20) (time-translation 27) (time-solving 6) (time-building 1708532243034)) ())
 
-		`;
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+        `;
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		let num_mutations = mutator.mutateToStudentMisunderstanding();
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        let num_mutations = mutator.mutateToStudentMisunderstanding();
 
 
 
-		const expectedMutant = `#lang forge
+        const expectedMutant = `#lang forge
 
-	  option run_sterling off
-	  
-	  sig Node {edges: set Node}
-	  
-	  pred isDirectedTree_inner1 {
-		edges.~edges in iden 
-		lone edges.Node - Node.edges 
-		no (^edges & iden) 
-		lone Node or Node in edges.Node + Node.edges 
-	  }
-	  
-	  pred loops {
-		   (some (^edges & iden))
-	  }
-	  pred mustHaveRoot {
-	  
-		  one edges.Node - Node.edges
-	  }
-	  
-			pred isDirectedTree_inner2 { 
-				 isDirectedTree_inner1 and loops
-			}
-			
-			pred isDirectedTree { 
-				 isDirectedTree_inner2 and mustHaveRoot
-			}`;
+      option run_sterling off
+      
+      sig Node {edges: set Node}
+      
+      pred isDirectedTree_inner1 {
+        edges.~edges in iden 
+        lone edges.Node - Node.edges 
+        no (^edges & iden) 
+        lone Node or Node in edges.Node + Node.edges 
+      }
+      
+      pred loops {
+           (some (^edges & iden))
+      }
+      pred mustHaveRoot {
+      
+          one edges.Node - Node.edges
+      }
+      
+            pred isDirectedTree_inner2 { 
+                 isDirectedTree_inner1 and loops
+            }
+            
+            pred isDirectedTree { 
+                 isDirectedTree_inner2 and mustHaveRoot
+            }`;
 
-		assert.strictEqual(num_mutations, 2);
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expectedMutant));
-	});
+        assert.strictEqual(num_mutations, 2);
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expectedMutant));
+    });
 
-	it(' : mutate to Misunderstanding can mutate on quantified assertion failures.', () => {
+    it(' : mutate to Misunderstanding can mutate on quantified assertion failures.', () => {
 
-		const tests = `
-		#lang forge
+        const tests = `
+        #lang forge
 
 //// Do not edit anything above this line ////
 
@@ -232,434 +231,431 @@ pred loops {
 
 assert loops is necessary for isDirectedTree
 assert all x : Node | loops is sufficient for isDirectedTree
-		  `;
-		const truncated_forge_output = `[aaa.test.frg:17:0 (span 44)] Theorem Assertion_loops_is_necessary_for_isDirectedTree failed. Found instance:
-		#(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 388) (size-clauses 555) (size-primary 20) (time-translation 98) (time-solving 8) (time-building 1708545113557)) ()) Sterling disabled, so reporting raw instance data:
-		#(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 388) (size-clauses 555) (size-primary 20) (time-translation 98) (time-solving 8) (time-building 1708545113557)) ())
-		
-		[aaa.test.frg:18:0 (span 60)] Theorem temporary-name_directedtree.test_1__Assertion_All_loops_is_sufficient_for_isDirectedTree failed. Found instance:
-		#(struct:Sat (#hash(($x_all7045 . ((Node3))) (Node . ((Node1) (Node2) (Node3))) (edges . ((Node1 Node1) (Node1 Node3) (Node2 Node2) (Node2 Node3) (Node3 Node1) (Node3 Node2))))) ((size-variables 418) (size-clauses 388) (size-primary 24) (time-translation 34) (time-solving 7) (time-building 1708545113696)) ()) Sterling disabled, so reporting raw instance data:
-		#(struct:Sat (#hash(($x_all7045 . ((Node3))) (Node . ((Node1) (Node2) (Node3))) (edges . ((Node1 Node1) (Node1 Node3) (Node2 Node2) (Node2 Node3) (Node3 Node1) (Node3 Node2))))) ((size-variables 418) (size-clauses 388) (size-primary 24) (time-translation 34) (time-solving 7) (time-building 1708545113696)) ())	`;
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
-
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, truncated_forge_output, DIRTREE_INFO.filename, source_text);
-		let num_mutations = mutator.mutateToStudentMisunderstanding();
-
-
-
-		const expectedMutant = `#lang forge
-
-		option run_sterling off
-		
-		sig Node {edges: set Node}
-		
-		pred isDirectedTree_inner1 {
-		 edges.~edges in iden 
-		 lone edges.Node - Node.edges 
-		 no (^edges & iden) 
-		 lone Node or Node in edges.Node + Node.edges 
-		}
-		
-		pred loops {
-			 (some (^edges & iden))
-		}
-		
-		   pred isDirectedTree_inner2 { 
-			  isDirectedTree_inner1 and loops
-		   }
-		   
-		   pred isDirectedTree { 
-			all x : Node |  isDirectedTree_inner2 or loops
-		   }`;
-
-		assert.strictEqual(num_mutations, 2);
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expectedMutant));
-	});
-
-
-
-
-	it(' : mutate to Misunderstanding carries out mutations on positive examples.', () => {
-
-		const tests = `
-		  
-			  #lang forge
-	
-			open "${DIRTREE_INFO.filename}"
-			//// Do not edit anything above this line ////
-		 
-		  
-		  example lasso is isDirectedTree for {
-			Node = \`Node1 + \`Node2
-			edges = \`Node1->\`Node2 + \`Node2->\`Node2
-		  }
-		  `;
-		const forge_output = `[directedtree.test.frg:13:0 (span 168)] Invalid example 'lasso'; the instance specified does not satisfy the given predicate. Sterling disabled, so reporting raw instance data:
-			#(struct:Unsat #f ((size-variables 0) (size-clauses 0) (size-primary 0) (time-translation 36) (time-solving 0) (time-building 1708545562033) (time-core 0)) unsat)
-			`;
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
-
-
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToStudentMisunderstanding();
-
-		const expected_mutant = `
-			#lang forge
-			option run_sterling off
-
-			  sig Node {edges: set Node}
-			  
-			  pred isDirectedTree_inner1 {
-					  edges.~edges in iden
-					  lone edges.Node - Node.edges 
-					  no (^edges & iden)
-					  lone Node or Node in edges.Node + Node.edges 
-			  }
-			  
-			  
-			  pred lasso {
-				  some disj Node1, Node2 : Node | {
-							  Node = Node1 + Node2
-							  edges = Node1->Node2 + Node2->Node2
-						  }
-			  }
-			  
-			  pred isDirectedTree { 
-			   isDirectedTree_inner1 or lasso
-			  }`;
-
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
-	});
-
-
-	it(' : mutate to Misunderstanding carries out mutations on negative examples.', () => {
-
-		const tests = `
-		  
-			  #lang forge
-	
-			open "${DIRTREE_INFO.filename}"
-			//// Do not edit anything above this line ////
-		 
-		  
-		  example line is {not isDirectedTree} for {
-			Node = \`Node1 + \`Node2
-			edges = \`Node1->\`Node2 
-		  }
-		  `;
-		const forge_output = `[directedtree.test.frg:13:0 (span 168)] Invalid example 'line'; the instance specified does not satisfy the given predicate. Sterling disabled, so reporting raw instance data:
-			#(struct:Unsat #f ((size-variables 0) (size-clauses 0) (size-primary 0) (time-translation 36) (time-solving 0) (time-building 1708545562033) (time-core 0)) unsat)
-			`;
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
-
-
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToStudentMisunderstanding();
-
-		const expected_mutant = `
-			#lang forge
-			option run_sterling off
-
-			  sig Node {edges: set Node}
-			  
-			  pred isDirectedTree_inner1 {
-					  edges.~edges in iden
-					  lone edges.Node - Node.edges 
-					  no (^edges & iden)
-					  lone Node or Node in edges.Node + Node.edges 
-			  }
-			  
-			  
-			  pred line {
-				  some disj Node1, Node2 : Node | {
-							  Node = Node1 + Node2
-							  edges = Node1->Node2
-						  }
-			  }
-			  
-			  pred isDirectedTree { 
-			   isDirectedTree_inner1 and not line
-			  }`;
-
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
-	});
-
-	it(' : mutate to Misunderstanding carries out mutations on examples and assertions when combined.', () => {
-
-		const tests = `
-		  
-			  #lang forge
-	
-			open "${DIRTREE_INFO.filename}"
-			//// Do not edit anything above this line ////
-		 
-			pred mustBeEmpty {
-				no edges
-		    }
-		   
-		   assert mustBeEmpty is necessary for isDirectedTree
-		  
-		  example loop is {isDirectedTree} for {
-			Node = \`Node1 + \`Node2
-			edges = \`Node1->\`Node2  + \`Node2->\`Node1
-		  }
-		  `;
-		const forge_output = `[directedtree.test.frg:21:19 (span 50)] Theorem Assertion_mustBeEmpty_is_necessary_for_isDirectedTree failed. Found instance:
-			#(struct:Sat (#hash((Node . ((Node2) (Node3))) (edges . ((Node3 Node2))))) ((size-variables 390) (size-clauses 558) (size-primary 20) (time-translation 77) (time-solving 9) (time-building 1708555673207)) ()) Sterling disabled, so reporting raw instance data:
-			#(struct:Sat (#hash((Node . ((Node2) (Node3))) (edges . ((Node3 Node2))))) ((size-variables 390) (size-clauses 558) (size-primary 20) (time-translation 77) (time-solving 9) (time-building 1708555673207)) ())
-			
-			[directedtree.test.frg:23:18 (span 114)] Invalid example 'loop'; the instance specified does not satisfy the given predicate. Sterling disabled, so reporting raw instance data:
-			#(struct:Unsat #f ((size-variables 0) (size-clauses 0) (size-primary 0) (time-translation 5) (time-solving 0) (time-building 1708555673326) (time-core 0)) unsat)			
-			`;
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
-
-
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToStudentMisunderstanding();
-
-		const expected_mutant = `#lang forge
-
-			  option run_sterling off
-			  
-			  sig Node {edges: set Node}
-			  
-			  pred isDirectedTree_inner1 {
-				edges.~edges in iden 
-				lone edges.Node - Node.edges 
-				no (^edges & iden) 
-				lone Node or Node in edges.Node + Node.edges 
-			  }
-			  
-			  pred mustBeEmpty {
-					  no edges
-			  }
-			  
-			  pred isDirectedTree_inner2 { 
-				  isDirectedTree_inner1 and mustBeEmpty
-			  }
-					
-			  pred loop {
-				  some disj Node1, Node2 : Node | {
-					  Node = Node1 + Node2
-					  edges = Node1->Node2  + Node2->Node1
-				  }
-			  }
-			  
-			  pred isDirectedTree { 
-				  isDirectedTree_inner2 or loop
-			  }`;
-
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
-	});
-
-
-	it(' : mutate to Understanding carries out no mutations if not in test suites.', () => {
-
-		const tests = `
-		  
-			  #lang forge
-	
-			open "${DIRTREE_INFO.filename}"
-//// Do not edit anything above this line ////
-		 
-				example e1 is isDirectedTree for {
-					Node = \`Node1 + \`Node2
-					edges = \`Node1->\`Node2
-				}
-
-				example e2 is isDirectedTree for {
-					Node = \`Node1 + \`Node2 + \`Node3
-					edges = \`Node2->\`Node1 + \`Node2->\`Node3
-				}
-		  `;
-		const forge_output = "";
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
-
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToStudentUnderstanding();
-
-		const expected_mutant = `#lang forge`
-
-		assert.strictEqual(mutator.num_mutations, 0);
-	});
-
-
-	it(' : mutate to Understanding carries mutations on examples.', () => {
-
-		const tests = `
-		  
-			  #lang forge
-	
-			open "${DIRTREE_INFO.filename}"
-			//// Do not edit anything above this line ////
-		 
-			test suite for isDirectedTree {
-				example e1 is isDirectedTree for {
-					Node = \`Node1 + \`Node2
-					edges = \`Node1->\`Node2
-				}
-
-				example e2 is isDirectedTree for {
-					Node = \`Node1 + \`Node2 + \`Node3
-					edges = \`Node2->\`Node1 + \`Node2->\`Node3
-				}
-			}
-		  `;
-		const forge_output = "";
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
-
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToStudentUnderstanding();
-
-		const expected_mutant = `
-			#lang forge
-
-			option run_sterling off
-
-			sig Node {edges: set Node}
-
-			pred isDirectedTree_inner1 {
-					edges.~edges in iden
-					lone edges.Node - Node.edges 
-					no (^edges & iden)
-					lone Node or Node in edges.Node + Node.edges 
-			}
-
-			pred e1 {
-				some disj Node1, Node2 : Node | {
-						Node = Node1 + Node2
-						edges = Node1->Node2
-						}
-				}
+          `;
+        const truncated_forge_output = `[aaa.test.frg:17:0 (span 44)] Theorem Assertion_loops_is_necessary_for_isDirectedTree failed. Found instance:
+        #(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 388) (size-clauses 555) (size-primary 20) (time-translation 98) (time-solving 8) (time-building 1708545113557)) ()) Sterling disabled, so reporting raw instance data:
+        #(struct:Sat (#hash((Node . ()) (edges . ()))) ((size-variables 388) (size-clauses 555) (size-primary 20) (time-translation 98) (time-solving 8) (time-building 1708545113557)) ())
         
-			pred e2 {
-				some disj Node1, Node2, Node3 : Node | {
-					Node = Node1 + Node2 + Node3
-					edges = Node2->Node1 + Node2->Node3
-					}
-			}
+        [aaa.test.frg:18:0 (span 60)] Theorem temporary-name_directedtree.test_1__Assertion_All_loops_is_sufficient_for_isDirectedTree failed. Found instance:
+        #(struct:Sat (#hash(($x_all7045 . ((Node3))) (Node . ((Node1) (Node2) (Node3))) (edges . ((Node1 Node1) (Node1 Node3) (Node2 Node2) (Node2 Node3) (Node3 Node1) (Node3 Node2))))) ((size-variables 418) (size-clauses 388) (size-primary 24) (time-translation 34) (time-solving 7) (time-building 1708545113696)) ()) Sterling disabled, so reporting raw instance data:
+        #(struct:Sat (#hash(($x_all7045 . ((Node3))) (Node . ((Node1) (Node2) (Node3))) (edges . ((Node1 Node1) (Node1 Node3) (Node2 Node2) (Node2 Node3) (Node3 Node1) (Node3 Node2))))) ((size-variables 418) (size-clauses 388) (size-primary 24) (time-translation 34) (time-solving 7) (time-building 1708545113696)) ())    `;
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-			pred isDirectedTree_inner2 { 
-						isDirectedTree_inner1 and not e1
-			}
-
-			pred isDirectedTree { 
-						isDirectedTree_inner2 and not e2
-			}
-			`;
-
-		assert.strictEqual(mutator.num_mutations, 2);
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
-	});
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, truncated_forge_output, DIRTREE_INFO.filename, source_text);
+        let num_mutations = mutator.mutateToStudentMisunderstanding();
 
 
-	it(' : mutate to Understanding carries mutations on assertions.', () => {
 
-		const tests = `
-		  
-			  #lang forge
-	
-			open "${DIRTREE_INFO.filename}"
-			//// Do not edit anything above this line ////
-		 
+        const expectedMutant = `#lang forge
 
-			pred a1 {
-				no (^edges & iden)
-			}
+        option run_sterling off
+        
+        sig Node {edges: set Node}
+        
+        pred isDirectedTree_inner1 {
+         edges.~edges in iden 
+         lone edges.Node - Node.edges 
+         no (^edges & iden) 
+         lone Node or Node in edges.Node + Node.edges 
+        }
+        
+        pred loops {
+             (some (^edges & iden))
+        }
+        
+           pred isDirectedTree_inner2 { 
+              isDirectedTree_inner1 and loops
+           }
+           
+           pred isDirectedTree { 
+            all x : Node |  isDirectedTree_inner2 or loops
+           }`;
 
-			pred a2 {
-				edges.~edges in iden 
-			}
-
-
-			test suite for isDirectedTree {
-				assert a1 is necessary for isDirectedTree
-				assert a2 is necessary for isDirectedTree
-			}
-		  `;
-		const forge_output = "";
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
-
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToStudentUnderstanding();
-
-		const expected_mutant = `
-			#lang forge
-
-			option run_sterling off
-	
-			sig Node {edges: set Node}
-	
-			pred isDirectedTree_inner1 {
-					edges.~edges in iden
-					lone edges.Node - Node.edges 
-					no (^edges & iden)
-					lone Node or Node in edges.Node + Node.edges 
-			}
-	
-	pred a1 {
-			no (^edges & iden)
-	}
-	pred a2 {
-			edges.~edges in iden 
-	}
-	
-	pred isDirectedTree_inner2 { 
-			 isDirectedTree_inner1 and not ( isDirectedTree_inner1 => a1)
-	}
-	
-	pred isDirectedTree { 
-			 isDirectedTree_inner2 and not ( isDirectedTree_inner2 => a2)
-	}
-			`;
-
-		assert.strictEqual(mutator.num_mutations, 2);
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
-	});
+        assert.strictEqual(num_mutations, 2);
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expectedMutant));
+    });
 
 
-	it(' : mutate to Understanding carries out mutations on negative examples.', () => {
 
-		const tests = `
-		  
-			#lang forge
-	
-			open "${DIRTREE_INFO.filename}"
+
+    it(' : mutate to Misunderstanding carries out mutations on positive examples.', () => {
+
+        const tests = `
+          
+              #lang forge
+    
+            open "${DIRTREE_INFO.filename}"
+            //// Do not edit anything above this line ////
+         
+          
+          example lasso is isDirectedTree for {
+            Node = \`Node1 + \`Node2
+            edges = \`Node1->\`Node2 + \`Node2->\`Node2
+          }
+          `;
+        const forge_output = `[directedtree.test.frg:13:0 (span 168)] Invalid example 'lasso'; the instance specified does not satisfy the given predicate. Sterling disabled, so reporting raw instance data:
+            #(struct:Unsat #f ((size-variables 0) (size-clauses 0) (size-primary 0) (time-translation 36) (time-solving 0) (time-building 1708545562033) (time-core 0)) unsat)
+            `;
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+
+
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToStudentMisunderstanding();
+
+        const expected_mutant = `
+            #lang forge
+            option run_sterling off
+
+              sig Node {edges: set Node}
+              
+              pred isDirectedTree_inner1 {
+                      edges.~edges in iden
+                      lone edges.Node - Node.edges 
+                      no (^edges & iden)
+                      lone Node or Node in edges.Node + Node.edges 
+              }
+              
+              
+              pred lasso {
+                  some disj Node1, Node2 : Node | {
+                              Node = Node1 + Node2
+                              edges = Node1->Node2 + Node2->Node2
+                          }
+              }
+              
+              pred isDirectedTree { 
+               isDirectedTree_inner1 or lasso
+              }`;
+
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+    });
+
+
+    it(' : mutate to Misunderstanding carries out mutations on negative examples.', () => {
+
+        const tests = `
+          
+              #lang forge
+    
+            open "${DIRTREE_INFO.filename}"
+            //// Do not edit anything above this line ////
+         
+          
+          example line is {not isDirectedTree} for {
+            Node = \`Node1 + \`Node2
+            edges = \`Node1->\`Node2 
+          }
+          `;
+        const forge_output = `[directedtree.test.frg:13:0 (span 168)] Invalid example 'line'; the instance specified does not satisfy the given predicate. Sterling disabled, so reporting raw instance data:
+            #(struct:Unsat #f ((size-variables 0) (size-clauses 0) (size-primary 0) (time-translation 36) (time-solving 0) (time-building 1708545562033) (time-core 0)) unsat)
+            `;
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+
+
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToStudentMisunderstanding();
+
+        const expected_mutant = `
+            #lang forge
+            option run_sterling off
+
+              sig Node {edges: set Node}
+              
+              pred isDirectedTree_inner1 {
+                      edges.~edges in iden
+                      lone edges.Node - Node.edges 
+                      no (^edges & iden)
+                      lone Node or Node in edges.Node + Node.edges 
+              }
+              
+              
+              pred line {
+                  some disj Node1, Node2 : Node | {
+                              Node = Node1 + Node2
+                              edges = Node1->Node2
+                          }
+              }
+              
+              pred isDirectedTree { 
+               isDirectedTree_inner1 and not line
+              }`;
+
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+    });
+
+    it(' : mutate to Misunderstanding carries out mutations on examples and assertions when combined.', () => {
+
+        const tests = `
+          
+              #lang forge
+    
+            open "${DIRTREE_INFO.filename}"
+            //// Do not edit anything above this line ////
+         
+            pred mustBeEmpty {
+                no edges
+            }
+           
+           assert mustBeEmpty is necessary for isDirectedTree
+          
+          example loop is {isDirectedTree} for {
+            Node = \`Node1 + \`Node2
+            edges = \`Node1->\`Node2  + \`Node2->\`Node1
+          }
+          `;
+        const forge_output = `[directedtree.test.frg:21:19 (span 50)] Theorem Assertion_mustBeEmpty_is_necessary_for_isDirectedTree failed. Found instance:
+            #(struct:Sat (#hash((Node . ((Node2) (Node3))) (edges . ((Node3 Node2))))) ((size-variables 390) (size-clauses 558) (size-primary 20) (time-translation 77) (time-solving 9) (time-building 1708555673207)) ()) Sterling disabled, so reporting raw instance data:
+            #(struct:Sat (#hash((Node . ((Node2) (Node3))) (edges . ((Node3 Node2))))) ((size-variables 390) (size-clauses 558) (size-primary 20) (time-translation 77) (time-solving 9) (time-building 1708555673207)) ())
+            
+            [directedtree.test.frg:23:18 (span 114)] Invalid example 'loop'; the instance specified does not satisfy the given predicate. Sterling disabled, so reporting raw instance data:
+            #(struct:Unsat #f ((size-variables 0) (size-clauses 0) (size-primary 0) (time-translation 5) (time-solving 0) (time-building 1708555673326) (time-core 0)) unsat)            
+            `;
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+
+
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToStudentMisunderstanding();
+
+        const expected_mutant = `#lang forge
+
+              option run_sterling off
+              
+              sig Node {edges: set Node}
+              
+              pred isDirectedTree_inner1 {
+                edges.~edges in iden 
+                lone edges.Node - Node.edges 
+                no (^edges & iden) 
+                lone Node or Node in edges.Node + Node.edges 
+              }
+              
+              pred mustBeEmpty {
+                      no edges
+              }
+              
+              pred isDirectedTree_inner2 { 
+                  isDirectedTree_inner1 and mustBeEmpty
+              }
+                    
+              pred loop {
+                  some disj Node1, Node2 : Node | {
+                      Node = Node1 + Node2
+                      edges = Node1->Node2  + Node2->Node1
+                  }
+              }
+              
+              pred isDirectedTree { 
+                  isDirectedTree_inner2 or loop
+              }`;
+
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+    });
+});
+
+
+
+describe('Mutator to Understanding', () => {
+
+    it(' : mutate to Understanding carries out no mutations if not in test suites.', () => {
+
+        const tests = `
+          
+              #lang forge
+    
+            open "${DIRTREE_INFO.filename}"
 //// Do not edit anything above this line ////
-		 
-		  test suite for isDirectedTree {
-			example lasso is !isDirectedTree for {
-				Node = \`Node1 + \`Node2
-				edges = \`Node1->\`Node2 + \`Node2->\`Node2
-			}
+         
+                example e1 is isDirectedTree for {
+                    Node = \`Node1 + \`Node2
+                    edges = \`Node1->\`Node2
+                }
 
-			example loop is {not isDirectedTree} for {
-				Node = \`Node1 + \`Node2
-				edges = \`Node1->\`Node2  + \`Node2->\`Node1
-			}
-		}
-		  `;
-		const forge_output = ``;
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+                example e2 is isDirectedTree for {
+                    Node = \`Node1 + \`Node2 + \`Node3
+                    edges = \`Node2->\`Node1 + \`Node2->\`Node3
+                }
+          `;
+        const forge_output = "";
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToPositiveTests();
+
+        const expected_mutant = `#lang forge`
+
+        assert.strictEqual(mutator.num_mutations, 0);
+    });
 
 
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToStudentUnderstanding();
+    it(' : mutate to positive examples carries mutations on examples.', () => {
 
-		const expected_mutant = `
-			                  
-#lang forge
+        const tests = `
+          
+              #lang forge
+    
+            open "${DIRTREE_INFO.filename}"
+            //// Do not edit anything above this line ////
+         
+            test suite for isDirectedTree {
+                example e1 is isDirectedTree for {
+                    Node = \`Node1 + \`Node2
+                    edges = \`Node1->\`Node2
+                }
 
-option run_sterling off
+                example e2 is isDirectedTree for {
+                    Node = \`Node1 + \`Node2 + \`Node3
+                    edges = \`Node2->\`Node1 + \`Node2->\`Node3
+                }
+            }
+          `;
+        const forge_output = "";
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-sig Node {edges: set Node}
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToPositiveTests();
 
-pred isDirectedTree_inner1 {
-        edges.~edges in iden
-        lone edges.Node - Node.edges 
-        no (^edges & iden)
-        lone Node or Node in edges.Node + Node.edges 
-}
+        const expected_mutant = `
+            #lang forge
+
+            option run_sterling off
+
+            sig Node {edges: set Node}
+
+            pred isDirectedTree_inner1 {
+                    edges.~edges in iden
+                    lone edges.Node - Node.edges 
+                    no (^edges & iden)
+                    lone Node or Node in edges.Node + Node.edges 
+            }
+
+            pred e1 {
+                some disj Node1, Node2 : Node | {
+                        Node = Node1 + Node2
+                        edges = Node1->Node2
+                        }
+                }
+        
+            pred e2 {
+                some disj Node1, Node2, Node3 : Node | {
+                    Node = Node1 + Node2 + Node3
+                    edges = Node2->Node1 + Node2->Node3
+                    }
+            }
+
+            pred isDirectedTree_inner2 { 
+                        isDirectedTree_inner1 and not e1
+            }
+
+            pred isDirectedTree { 
+                        isDirectedTree_inner2 and not e2
+            }
+            `;
+
+        assert.strictEqual(mutator.num_mutations, 2);
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+    });
+
+
+    it(' : mutate to negative tests carries out mutations on assertions.', () => {
+
+        const tests = `
+          
+              #lang forge
+    
+            open "${DIRTREE_INFO.filename}"
+            //// Do not edit anything above this line ////
+         
+
+            pred a1 {
+                no (^edges & iden)
+            }
+
+            pred a2 {
+                edges.~edges in iden 
+            }
+
+
+            test suite for isDirectedTree {
+                assert a1 is necessary for isDirectedTree
+                assert isDirectedTree is sufficient for a2
+            }
+          `;
+        const forge_output = "";
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToNegativeTests();
+
+        const expected_mutant = `
+            #lang forge
+
+            option run_sterling off
+    
+            sig Node {edges: set Node}
+    
+            pred isDirectedTree_inner1 { }
+    
+    pred a1 {
+            no (^edges & iden)
+    }
+    pred a2 {
+            edges.~edges in iden 
+    }
+    
+    pred isDirectedTree_inner2 { 
+             isDirectedTree_inner1 and a1
+    }
+    
+    pred isDirectedTree { 
+             isDirectedTree_inner2 and  a2
+    }
+            `;
+
+        assert.strictEqual(mutator.num_mutations, 2);
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+    });
+
+
+    it(' : mutate to negative tests carries out mutations on negative examples.', () => {
+
+        const tests = `
+          
+            #lang forge
+    
+            open "${DIRTREE_INFO.filename}"
+//// Do not edit anything above this line ////
+         
+          test suite for isDirectedTree {
+            example lasso is !isDirectedTree for {
+                Node = \`Node1 + \`Node2
+                edges = \`Node1->\`Node2 + \`Node2->\`Node2
+            }
+
+            example loop is {not isDirectedTree} for {
+                Node = \`Node1 + \`Node2
+                edges = \`Node1->\`Node2  + \`Node2->\`Node1
+            }
+        }
+          `;
+        const forge_output = ``;
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+
+
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToNegativeTests();
+
+
+
+        const expected_mutant = `
+                              
+        #lang forge
+
+        option run_sterling off
+
+        sig Node {edges: set Node}
+
+        pred isDirectedTree_inner1 {}
+
 
 pred lasso {
 some disj Node1, Node2 : Node | {
@@ -671,6 +667,11 @@ edges = Node1->Node2 + Node2->Node2
 }
 
 }
+
+pred isDirectedTree_inner2 { 
+         isDirectedTree_inner1 and not lasso
+}
+
 pred loop {
 some disj Node1, Node2 : Node | {
 
@@ -681,53 +682,52 @@ edges = Node1->Node2  + Node2->Node1
 }
 
 }
-pred isDirectedTree_inner2 { 
- isDirectedTree_inner1 or lasso
-}
 
 pred isDirectedTree { 
- isDirectedTree_inner2 or loop
+         isDirectedTree_inner2 and not loop
 }`;
-		assert.strictEqual(mutator.num_mutations, 2);
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
-	});
+        assert.strictEqual(mutator.num_mutations, 2);
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+    });
 
 
 
-	it(' : mutate to Understanding carries mutations on quantified assertions.', () => {
+    it(' : mutate to positive test carries mutations on quantified assertions only if they are positive.', () => {
 
-		const tests = `
-		  
-			  #lang forge
-	
-			open "${DIRTREE_INFO.filename}"
-			//// Do not edit anything above this line ////
-		 
-			// sufficient
-			pred a1[r : Node] {
-				one Node
-				r->r not in edges
-			}
+        const tests = `
+          
+              #lang forge
+    
+            open "${DIRTREE_INFO.filename}"
+            //// Do not edit anything above this line ////
+         
+            // sufficient
+            pred a1[r : Node] {
+                one Node
+                r->r not in edges
+            }
 
-			// necessary
-			pred a2[n : Node] {
-				n not in (^edges & iden)
-			}
+            // necessary
+            pred a2[n : Node] {
+                n not in (^edges & iden)
+            }
 
 
-			test suite for isDirectedTree {
-				assert all x : Node | a1[x] is sufficient for isDirectedTree
-				assert all x : Node | a2[x] is necessary for isDirectedTree
-			}
-		  `;
-		const forge_output = "";
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+            test suite for isDirectedTree {
+                assert all x : Node | a1[x] is sufficient for isDirectedTree
+                assert all x : Node | a2[x] is necessary for isDirectedTree
+            }
+          `;
+        const forge_output = "";
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToStudentUnderstanding();
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToPositiveTests();
 
-		const expected_mutant = `
-			#lang forge
+        
+
+        const expected_mutant = `
+            #lang forge
 
 option run_sterling off
 
@@ -748,110 +748,206 @@ pred a2[n : Node] {
         n not in (^edges & iden)
 }
 
-pred isDirectedTree_inner2 { 
-                isDirectedTree_inner1 and not (all x : Node | a1[x] => isDirectedTree_inner1)
-}
 
 pred isDirectedTree { 
-                isDirectedTree_inner2 and not (all x : Node | isDirectedTree_inner2 => a2[x])
+    isDirectedTree_inner1 and not (all x : Node | a1[x] => isDirectedTree_inner1)
 }
-			`;
+            `;
 
-		assert.strictEqual(mutator.num_mutations, 2);
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
-	});
-
-
-
-	it(' : mutate to Understanding carries mutations out when tests are of various types.', () => {
-
-		const tests = `
-		  
-			  #lang forge
-	
-			open "${DIRTREE_INFO.filename}"
-			//// Do not edit anything above this line ////
-		 
-			// sufficient
-			pred a1[r : Node] {
-				one Node
-				r->r not in edges
-			}
-
-			pred a2 {
-				edges.~edges in iden 
-			}
-
-			example willBeIgnored is isDirectedTree for {
-				Node = \`Node1
-				no edges
-			}
-
-			test suite for isDirectedTree {
-				assert all x : Node | a1[x] is sufficient for isDirectedTree
-				assert a2 is necessary for isDirectedTree
+        assert.strictEqual(mutator.num_mutations, 1);
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+    });
 
 
-				example lasso is !isDirectedTree for {
-					Node = \`Node1 + \`Node2
-					edges = \`Node1->\`Node2 + \`Node2->\`Node2
-				}
+    it(' : mutate to negative test carries mutations on quantified assertions only if they are negative.', () => {
+
+        const tests = `
+          
+              #lang forge
+    
+            open "${DIRTREE_INFO.filename}"
+            //// Do not edit anything above this line ////
+         
+            // sufficient
+            pred a1[r : Node] {
+                one Node
+                r->r not in edges
+            }
+
+            // necessary
+            pred a2[n : Node] {
+                n not in (^edges & iden)
+            }
 
 
-			}
-		  `;
-		const forge_output = "";
-		const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+            test suite for isDirectedTree {
+                assert all x : Node | a1[x] is sufficient for isDirectedTree
+                assert all x : Node | a2[x] is necessary for isDirectedTree
+            }
+          `;
+        const forge_output = "";
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
 
-		const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
-		mutator.mutateToStudentUnderstanding();
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToNegativeTests();
 
 
-		const expected_mutant = `#lang forge
 
-option run_sterling off
+        const expected_mutant = `
+        #lang forge
 
-sig Node {edges: set Node}
+        option run_sterling off
 
-pred isDirectedTree_inner1 {
-        edges.~edges in iden
-        lone edges.Node - Node.edges 
-        no (^edges & iden)
-        lone Node or Node in edges.Node + Node.edges 
-}
+        sig Node {edges: set Node}
+
+        pred isDirectedTree_inner1 {}
 
 pred a1[r : Node] {
         one Node
         r->r not in edges
 }
-pred a2 {
-    edges.~edges in iden 
-}
-pred lasso {
-        some disj Node1, Node2 : Node | {
-                Node = Node1 + Node2
-                edges = Node1->Node2 + Node2->Node2
-        }
-}
-
-pred isDirectedTree_inner2 { 
-        isDirectedTree_inner1 or lasso
-}
-
-pred isDirectedTree_inner3 { 
-        isDirectedTree_inner2 and not ( isDirectedTree_inner2 => a2)
+pred a2[n : Node] {
+        n not in (^edges & iden)
 }
 
 pred isDirectedTree { 
-        isDirectedTree_inner3 and not (all x : Node | a1[x] => isDirectedTree_inner3)
+         all x : Node | isDirectedTree_inner1 and a2[x]
 }
-			`;
+            `;
 
-		assert.strictEqual(mutator.num_mutations, 3);
-		assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
-	});
+        assert.strictEqual(mutator.num_mutations, 1);
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+    });
+
+
+    it(' : mutate to positive test carries mutations out when tests are of various types, but ignores negative tests.', () => {
+
+        const tests = `
+          
+              #lang forge
+    
+            open "${DIRTREE_INFO.filename}"
+            //// Do not edit anything above this line ////
+         
+            // sufficient
+            pred a1[r : Node] {
+                one Node
+                r->r not in edges
+            }
+
+            pred a2 {
+                edges.~edges in iden 
+            }
+
+            example willBeIgnored is isDirectedTree for {
+                Node = \`Node1
+                no edges
+            }
+
+            test suite for isDirectedTree {
+                assert all x : Node | a1[x] is sufficient for isDirectedTree
+                assert a2 is necessary for isDirectedTree
+
+
+                example lasso is !isDirectedTree for {
+                    Node = \`Node1 + \`Node2
+                    edges = \`Node1->\`Node2 + \`Node2->\`Node2
+                }
+
+
+            }
+          `;
+        const forge_output = "";
+        const source_text = combineTestsWithModel(DIRTREE_INFO.wheat, tests);
+
+        const mutator = new Mutator(DIRTREE_INFO.wheat, tests, forge_output, DIRTREE_INFO.filename, source_text);
+        mutator.mutateToPositiveTests();
+
+            
+        const expected_mutant = `
+        #lang forge
+
+                                option run_sterling off
+
+                                sig Node {edges: set Node}
+
+                                pred isDirectedTree_inner1 {
+                                        edges.~edges in iden
+                                        lone edges.Node - Node.edges 
+                                        no (^edges & iden)
+                                        lone Node or Node in edges.Node + Node.edges 
+                                }
+
+pred a1[r : Node] {
+                                one Node
+                                r->r not in edges
+                        }
+pred a2 {
+                                edges.~edges in iden 
+                        }
+
+		pred isDirectedTree { 
+					isDirectedTree_inner1 and not (all x : Node | a1[x] => isDirectedTree_inner1)
+		}
+
+            `;
+
+        assert.strictEqual(mutator.num_mutations, 1);
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expected_mutant));
+    });
 
 
 });
 
 
+describe('Mutator to Vaccuity', () => {
+    it(' : mutate to Vaccuity removes all predicate bodies', () => {
+
+        const source = `
+      
+        #lang forge
+
+        option run_sterling off
+
+        sig Node {edges: set Node}
+
+        pred isDirectedTree {
+            edges.~edges in iden
+            lone edges.Node - Node.edges 
+            no (^edges & iden)
+            lone Node or Node in edges.Node + Node.edges 
+        }
+
+
+        pred isDir [n : Node] {
+            n in Node
+        }
+
+        pred abc [n : Node, n2 : Node] 
+        {
+            n1 = n2
+        }
+
+      `;
+        const expectedMutant = `        #lang forge
+
+        option run_sterling off
+
+        sig Node {edges: set Node}
+
+        pred isDirectedTree {   }
+
+
+        pred isDir [n : Node] { }
+
+        pred abc [n : Node, n2 : Node] 
+        {
+        }
+`;
+
+
+        const mutator = new Mutator(source, "", "", "", "");
+        mutator.mutateToVaccuity();
+        assert.strictEqual(removeWhitespace(mutator.mutant), removeWhitespace(expectedMutant));
+    });
+});

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"description": "Forge Language Server",
 	"author": "",
 	"license": "",
-	"version": "2.3.2",
+	"version": "2.3.3",
 	"repository": {
 		"type": "git",
 		"url": ""
@@ -84,11 +84,16 @@
 					"default": "Comprehensive",
 					"description": "Feedback strategy used by Toadus Ponens. Comprehensive will provide feedback for the test suite as a whole, Per Test will provide feedback for each test."
 				},
-				"forge.thoroughnessFeedbackEnabled": {
+				"forge.thoroughnessFeedback": {
 					"scope": "resource",
-					"type": "boolean",
-					"default": true,
-					"description": "Determines if the experimental Toadus Ponens test feedback feature is enabled"
+					"type": "string",
+					"enum": [
+						"Off",
+						"Partial",
+						"Full"
+					],
+					"default": "Partial",
+					"description": "Determines the level of thoroughness feedback given by Toadus Ponens. Full offers more accurate thoroughness feedback, but is experimental and may be buggy."
 				}
 			}
 		},


### PR DESCRIPTION
* There is an issue with the current mutation stratgey, which works only when all tests are positive.

This change segregates tests into positive and negative tests. Then, for positive tests, it removes any tests in the intersection of the property and the predicate and run against the autograder to generate hints (passing = hint) For negative tests, I build student predicates from scratch using their necessary assertions. I run the autograder against this (fail = hint). Finally, we serve hints from the intersection of the two (ie - not caught by the +ve mutation or the negative mutation)