### PR TITLE
Introducing Toadus Ponens timeout

### DIFF
--- a/client/src/conceptualmutator.ts
+++ b/client/src/conceptualmutator.ts
@@ -1,7 +1,6 @@
 import { combineTestsWithModel } from './forge-utilities';
 import { getFailingTestData } from './forge-utilities';
-
-
+import * as vscode from 'vscode';
 import {
 	ForgeUtil,
 	Block, SyntaxNode,
@@ -195,9 +194,6 @@ export class ConceptualMutator {
 		this.full_source_util.processSpec();
 		this.inconsistent_tests = [];
 		this.skipped_tests = [];
-
-
-
 
 
 		// TODO: Maybe this should keep track of the passing and failing tests rather than the calling code.
@@ -644,6 +640,8 @@ export class ConceptualMutator {
 			return;
 		}
 
+		this.testExprReferencesPredUnderTestWarning(test_name, exp, pred);
+
 		this.inconsistent_tests.push(test_name);
 
 		if (rel === "necessary") {
@@ -672,6 +670,7 @@ export class ConceptualMutator {
 		const quantDecls = get_text_from_syntaxnode(a.quantDecls, this.source_text);
 		const quantifiedPrefix = `${quantifier} ${disj} ${quantDecls} | `;
 
+		this.testExprReferencesPredUnderTestWarning(test_name, exp, pred);
 		this.inconsistent_tests.push(test_name);
 		if (rel === "necessary") {
 			this.constrainPredicateByInclusion(pred, exp, quantifiedPrefix, pred_args);
@@ -734,7 +733,7 @@ export class ConceptualMutator {
 			this.skipped_tests.push(new SkippedTest(a.name, `Assertion does not directly test a predicate from the assignment statement.`));
 			return;
 		}
-
+		this.testExprReferencesPredUnderTestWarning(test_name, exp, pred);
 		this.inconsistent_tests.push(test_name);
 		// If isconsistent, then they believe pred & exp is SAT.
 		// SO WE need to EASE the predicate to ALLOW the expression.
@@ -1006,17 +1005,16 @@ export class ConceptualMutator {
 	}
 
 
-	private testExprReferencesPredUnderTest(e: string, p: string): boolean {
+	private testExprReferencesPredUnderTestWarning(testname: string, e: string, p: string) {
 
 		// Check if e contains p with word boundaries.
 		const regex = new RegExp(`\\b${p}\\b`);
-		return regex.test(e);
+		let references_pred = regex.test(e);
 
-
-
-		return false;
+		if (references_pred) {
+			vscode.window.showInformationMessage(`Warning: ${testname} references '${p}', on both sides of the assertion. This *may* cause Toadus Ponens to time out.`);
+		}
 	}
-
 	
 	private getPredArgs(predArgs : SyntaxNode | undefined) : string {
 		if (!predArgs) {

--- a/client/src/conceptualmutator.ts
+++ b/client/src/conceptualmutator.ts
@@ -25,8 +25,7 @@ class SkippedTest {
 function isAssertionTest(t: any): t is AssertionTest {
 	return t && typeof t === 'object' && 
 			'prop' in t && 'pred' in t 
-			&& !(t as QuantifiedAssertionTest).quantifier
-			&& !(t as ConsistencyAssertionTest).consistent;
+			&& !('consistent' in t) && !('quantifier' in t);
 }
 
 function isQuantifiedAssertionTest(t: any): t is QuantifiedAssertionTest {
@@ -1002,6 +1001,18 @@ export class ConceptualMutator {
 			const isConsistent = ca.consistent;
 			return this.isInstructorAuthored(p) && !isConsistent;
 		}
+
+		return false;
+	}
+
+
+	private testExprReferencesPredUnderTest(e: string, p: string): boolean {
+
+		// Check if e contains p with word boundaries.
+		const regex = new RegExp(`\\b${p}\\b`);
+		return regex.test(e);
+
+
 
 		return false;
 	}

--- a/client/src/hintgenerator.ts
+++ b/client/src/hintgenerator.ts
@@ -388,7 +388,7 @@ export class HintGenerator {
 
 
 
-	private runTestsAgainstModelWithTimeout(tests: string, model: string, timeout: number = 60000): Promise<RunResult> {
+	private runTestsAgainstModelWithTimeout(tests: string, model: string, timeout: number = 120000): Promise<RunResult> {
 		// This function is a wrapper around runTestsAgainstModel that adds a timeout.
 		return new Promise((resolve, reject) => {
 			// Set a timeout to reject the promise if the operation takes too long

--- a/client/src/hintgenerator.ts
+++ b/client/src/hintgenerator.ts
@@ -30,16 +30,16 @@ const ANALYZED_CONSISTENCY_MESSAGE = `🎉 Analyzed tests are all consistent wit
 										 However, the tests we could not analyze are either 
 										 inconsistent with or test behavior not specified by the problem statement.`;
 
+const TIMEOUT_MESSAGE = "Toadus Ponens timed out.";
+
 export class HintGenerator {
 
 	private SOMETHING_WENT_WRONG = "Something went wrong during Toadus Ponens analysis. While I will still make a best effort to provide useful feedback, consider examining your tests with course staff. You may find it useful to share the the VSCode Error log with them. You can access it as follows: Ctrl-shift-p or cmd-shift-p -> Search Show Logs -> Extension Host";
-	//static WHEATSTORE = "https://csci1710.github.io/2024/toadusponensfiles"; // TODO: This needs to change.
-
 
 	    // Read WHEATSTORE URL from VS Code settings
 	static get WHEATSTORE(): string {
 		const config = vscode.workspace.getConfiguration('forge');
-		return config.get<string>('toadusSource', 'https://csci1710.github.io/2024/toadusponensfiles');
+		return config.get<string>('toadusSource', 'https://csci1710.github.io/2025/toadusponensfiles');
 	}
 
 	logger: Logger;
@@ -86,6 +86,7 @@ export class HintGenerator {
 		const run_result = await this.runTestsAgainstModelWithTimeout(studentTests, w);
 		const w_o = run_result.stderr;
 		const source_text = run_result.runsource;
+		
 
 		// Step 2: If all the tests pass the wheat, we know they are consistent with the problem specification.
 		// We MAY want to generate feedback around thoroughness.
@@ -393,9 +394,9 @@ export class HintGenerator {
 			// Set a timeout to reject the promise if the operation takes too long
 			const timeoutId = setTimeout(() => {
 				// Show a timeout message in the VS Code error window
-				vscode.window.showErrorMessage("Toadus Ponens timed out.");
+				vscode.window.showErrorMessage(TIMEOUT_MESSAGE);
 				// Resolve the promise with a timeout result if the operation takes too long
-				resolve(new RunResult("Toadus Ponens timed out.", "", tests));
+				resolve(new RunResult(TIMEOUT_MESSAGE, TIMEOUT_MESSAGE, tests));
 			}, timeout);
 	
 			// Call the runTestsAgainstModel function and handle its result
@@ -562,6 +563,11 @@ export class HintGenerator {
 		const ag_meta = await this.runTestsAgainstModelWithTimeout(autograderTests, mutant);
 		const ag_output = ag_meta.stderr;
 
+		if (ag_output == TIMEOUT_MESSAGE) {
+			return [TIMEOUT_MESSAGE];
+		}
+
+
 		// Step 4. Extract hints from the output.
 		return await this.tryGetFailingHintsFromAutograderOutput(ag_output, testFileName);
 	}
@@ -594,6 +600,11 @@ export class HintGenerator {
 		const autograderTests = await this.getAutograderTests(testFileName);
 		const ag_meta = await this.runTestsAgainstModelWithTimeout(autograderTests, mutant);
 		const ag_output = ag_meta.stderr;
+
+		if (ag_output == TIMEOUT_MESSAGE) {
+			return [TIMEOUT_MESSAGE];
+		}
+
 		return await this.tryGetPassingHintsFromAutograderOutput(ag_output, testFileName);
 	}
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"description": "Forge Language Server",
 	"author": "Siddhartha Prasad",
 	"license": "",
-	"version": "3.3.3",
+	"version": "3.4.0",
 	"repository": {
 		"type": "git",
 		"url": ""


### PR DESCRIPTION
- Introducing 2 minute timeout on Toadus Ponens runs and warnings for potential recursion caused by tests
- For instance, a test could trigger a mutation with circular predicate references, and we cannot catch this / predict this.
Flag the test if possible (for assertions) and move on.