### PR TITLE
Support for named assertions

### DIFF
--- a/client/src/conceptualmutator.ts
+++ b/client/src/conceptualmutator.ts
@@ -1027,6 +1027,15 @@ export class ConceptualMutator {
 
 	private getTestName(t: AssertionTest | Example | QuantifiedAssertionTest | ConsistencyAssertionTest): string {
 
+
+		// If t has a name, then we can use that.
+
+		if (t.name) {
+			return t.name;
+		}
+
+
+
 		// The problem here is that
 		// 1. We remove comments in the 'source_text' but not in the 'student_tests'
 		// 2. The student test has stuff above the '//// Do not edit anything above this line ////' line.

--- a/client/src/conceptualmutator.ts
+++ b/client/src/conceptualmutator.ts
@@ -233,6 +233,12 @@ export class ConceptualMutator {
 	}
 
 
+
+
+
+
+	
+
 	
 
 	/**
@@ -252,6 +258,10 @@ export class ConceptualMutator {
 			if (this.isTestOfInclusion(e)) {
 				this.mutateAwayExample(e);
 			}
+			else if (!this.isTestOfExclusion(e)) {
+				this.skipped_tests.push(new SkippedTest(e.name, `Example does not directly test a predicate (or its negation) from the assignment statement.`));
+			}
+
 		}
 
 		for (const a of assertions) {
@@ -263,6 +273,9 @@ export class ConceptualMutator {
 				const pred = a.pred;
 				const exp = get_text_from_syntaxnode(a.prop, this.source_text);
 				this.constrainPredicateByExclusion(pred, exp);
+			}
+			else if (!this.isTestOfExclusion(a)) {
+				this.skipped_tests.push(new SkippedTest(a.name, `Assertion does not directly test a predicate from the assignment statement.`));
 			}
 		}
 
@@ -278,6 +291,9 @@ export class ConceptualMutator {
 				const quantifiedPrefix = `${quantifier} ${disj} ${quantDecls} | `;
 				this.constrainPredicateByExclusion(pred, exp, quantifiedPrefix, pred_args);
 			}
+			else if (!this.isTestOfExclusion(qa)) {
+				this.skipped_tests.push(new SkippedTest(qa.name, `Assertion does not directly test a predicate from the assignment statement.`));
+			}
 		}
 
 		for (const ca of consistencyAssertions) {
@@ -287,6 +303,9 @@ export class ConceptualMutator {
 				const exp = get_text_from_syntaxnode(ca.prop, this.source_text);
 
 				this.constrainPredicateByExclusion(pred, exp);
+			}
+			else if (!this.isTestOfExclusion(ca)) {
+				this.skipped_tests.push(new SkippedTest(ca.name, `Assertion does not directly test a predicate from the assignment statement.`));
 			}
 		}
 
@@ -315,6 +334,9 @@ export class ConceptualMutator {
 				// Ensure the mutant does not accept the example.
 				this.mutateAwayExample(e);
 			}
+			else if (!this.isTestOfInclusion(e)) {
+				this.skipped_tests.push(new SkippedTest(e.name, `Example does not directly test a predicate (or its negation) from the assignment statement.`));
+			}
 		}
 
 		for (const a of assertions) {
@@ -331,6 +353,10 @@ export class ConceptualMutator {
 				// So we want to 
 				this.constrainPredicateByInclusion(pred, exp);
 			}
+			else if (!this.isTestOfInclusion(a)) {
+				this.skipped_tests.push(new SkippedTest(a.name, `Assertion does not directly test a predicate from the assignment statement.`));
+			}
+
 		}
 
 		for (const qa of quantifiedAssertions) {
@@ -348,6 +374,9 @@ export class ConceptualMutator {
 				this.constrainPredicateByInclusion(pred, exp, quantifiedPrefix, pred_args);
 
 			}
+			else if (!this.isTestOfInclusion(qa)) {
+				this.skipped_tests.push(new SkippedTest(qa.name, `Assertion does not directly test a predicate from the assignment statement.`));
+			}
 		}
 
 		for (const ca of consistencyAssertions) {
@@ -356,6 +385,9 @@ export class ConceptualMutator {
 				const pred = ca.pred;
 				const exp = get_text_from_syntaxnode(ca.prop, this.source_text);
 				this.constrainPredicateByExclusion(pred, exp); // Exclude exp from pred.
+			}
+			else if (!this.isTestOfInclusion(ca)) {
+				this.skipped_tests.push(new SkippedTest(ca.name, `Assertion does not directly test a predicate from the assignment statement.`));
 			}
 		}
 
@@ -766,6 +798,11 @@ export class ConceptualMutator {
 		});
 		return skipped_test_strings.join("\n");
 	}
+
+	public get_skipped_tests(): SkippedTest[] {
+		return this.skipped_tests;
+	}
+
 	///////////////////////////////////////////////////////////////////////////////////
 
 
@@ -982,6 +1019,8 @@ export class ConceptualMutator {
 	}
 
 
+	
+
 	private testExprReferencesPredUnderTestWarning(testname: string, e: string, p: string) {
 
 		// Check if e contains p with word boundaries.
@@ -1078,6 +1117,11 @@ export class ConceptualMutator {
 
 		return "unknown_test";
 	}
+
+	
+
+	
+
 
 }
 

--- a/client/src/conceptualmutator.ts
+++ b/client/src/conceptualmutator.ts
@@ -379,14 +379,14 @@ export class ConceptualMutator {
 			}
 
 			const testName = testData.name;
-			const testType = testData.type; // Can we do better here?
+
 
 
 			const asExample = this.getExampleByName(testName);
 			const asAssertion = this.getAssertion(testData.startRow, testData.startCol);
 			const asQuantifiedAssertion = this.getQuantifiedAssertion(testData.startRow, testData.startCol);
 			const asConsistencyAssertion = this.getConsistencyAssertion(testData.startRow, testData.startCol);
-			const asSatisfiabilityAssertion = this.getSatisfactionAssertion(testData.startRow, testData.startCol);
+			
 
 
 

--- a/client/src/forge-utilities.ts
+++ b/client/src/forge-utilities.ts
@@ -92,55 +92,6 @@ export function getFailingTestsData(o: string): TestData[] {
 // TODO: This needs to be RE-WRITTEN now that the test name is NOT obvious.
 // TODO: Should we abstract out getting the test NAME, type, and location?
 export function getFailingTestData(o: string): TestData {
-
-
-
-	// if (quantified_assertion_regex.test(o)) {
-	// 	const match = o.match(quantified_assertion_regex);
-
-	// 	if (match == null) {
-	// 		return undefined;
-	// 	}
-
-	// 	let testName = match[4] + "_quantified_assertion_for_" + match[5] + "_" + match[6];
-	// 	return new TestData(testName,
-	// 						"quantified_assertion",
-	// 						 parseInt(match[1]),
-	// 						 parseInt(match[2]),
-	// 						 parseInt(match[3]), o);
-
-	// 	// Entire string is match[0]
-	// 	// Line number is match[1]
-	// 	// Column number is match[2]
-	// 	// Span is match[3]
-	// 	// Direction of assertion is match[4]
-	// 	// Predicate name is match[5]
-	// 	// Temp name is match[6]
-
-	// } else if (assertion_regex.test(o)) {
-	// 	const match = o.match(assertion_regex);
-	// 	if (match == null) {
-	// 		return undefined;
-	// 	}
-
-
-	// 	// Entire string is match[0]
-	// 	// Line number is match[1]
-	// 	// Column number is match[2]
-	// 	// Span is match[3]
-	// 	// Direction of assertion is match[4]
-	// 	// Predicate name is match[5]
-	// 	// Temp name is match[6]
-
-	// 	let test_name = match[4] + "_assertion_for_" + match[5] + "_" + match[6];
-	// 	return new TestData(test_name,
-	// 						"assertion",
-	// 						 parseInt(match[1]),
-	// 						 parseInt(match[2]),
-	// 						 parseInt(match[3]), o);
-
-	// } else 
-	
 	
 	if (example_regex.test(o)) {
 		const match = o.match(example_regex);

--- a/client/src/forge-utilities.ts
+++ b/client/src/forge-utilities.ts
@@ -67,15 +67,18 @@ export function findForgeExamples(inputText) {
  * Regex for extracting failing test names, types, and/or locations
  */
 export const example_regex = 			  	/Invalid example '(\w+)'; the instance specified does not satisfy the given predicate\./;
-const quantified_assertion_regex = 	/:(\d+):(\d+) \(span (\d+)\)\] Test quantified_(\w+)_assertion_for_(\w+)_([^\s\\]*) failed./;
-const assertion_regex = 				/:(\d+):(\d+) \(span (\d+)\)\] Test (\w+)_assertion_for_(\w+)_([^\s\\]*) failed./;
-const consistency_assertion_regex =  /:(\d+):(\d+) \(span (\d+)\)\] Failed test (consistent|inconsistent)_assertion_for_(\w+)_([^\s\\]*)/;
-const satisfaction_assertion_regex = /:(\d+):(\d+) \(span (\d+)\)\] Failed test (sat|unsat|forge_error)_assertion_([^\s\\]*)/;
+// const quantified_assertion_regex = 	/:(\d+):(\d+) \(span (\d+)\)\] Test quantified_(\w+)_assertion_for_(\w+)_([^\s\\]*) failed./;
+// const assertion_regex = 				/:(\d+):(\d+) \(span (\d+)\)\] Test (\w+)_assertion_for_(\w+)_([^\s\\]*) failed./;
+// const consistency_assertion_regex =  /:(\d+):(\d+) \(span (\d+)\)\] Failed test (consistent|inconsistent)_assertion_for_(\w+)_([^\s\\]*)/;
+// const satisfaction_assertion_regex = /:(\d+):(\d+) \(span (\d+)\)\] Failed test (sat|unsat|forge_error)_assertion_([^\s\\]*)/;
+
+
+const test_with_span_regex = /:(\d+):(\d+) \(span (\d+)\)\] (?:Failed test (\w+)|Test (\w+) failed)\./;
 const test_regex = 					/Failed test (\w+)\.|Theorem (\w+) failed|Test (\w+) failed\./;
 
 export class TestData {
 
-	constructor(public name: string, public type: string, public startRow: number,
+	constructor(public name: string, public startRow: number,
 		public startCol: number, public span: number, public forgeOutput: string){ }
 }
 
@@ -91,62 +94,56 @@ export function getFailingTestsData(o: string): TestData[] {
 // TODO: Should we abstract out getting the test NAME, type, and location?
 export function getFailingTestData(o: string): TestData {
 
-	// TODO: Rewrite.
-	// If a test HAS a name ...
 
 
+	// if (quantified_assertion_regex.test(o)) {
+	// 	const match = o.match(quantified_assertion_regex);
+
+	// 	if (match == null) {
+	// 		return undefined;
+	// 	}
+
+	// 	let testName = match[4] + "_quantified_assertion_for_" + match[5] + "_" + match[6];
+	// 	return new TestData(testName,
+	// 						"quantified_assertion",
+	// 						 parseInt(match[1]),
+	// 						 parseInt(match[2]),
+	// 						 parseInt(match[3]), o);
+
+	// 	// Entire string is match[0]
+	// 	// Line number is match[1]
+	// 	// Column number is match[2]
+	// 	// Span is match[3]
+	// 	// Direction of assertion is match[4]
+	// 	// Predicate name is match[5]
+	// 	// Temp name is match[6]
+
+	// } else if (assertion_regex.test(o)) {
+	// 	const match = o.match(assertion_regex);
+	// 	if (match == null) {
+	// 		return undefined;
+	// 	}
 
 
-	// Else if a test is IMPLICITLY named, ...
+	// 	// Entire string is match[0]
+	// 	// Line number is match[1]
+	// 	// Column number is match[2]
+	// 	// Span is match[3]
+	// 	// Direction of assertion is match[4]
+	// 	// Predicate name is match[5]
+	// 	// Temp name is match[6]
 
+	// 	let test_name = match[4] + "_assertion_for_" + match[5] + "_" + match[6];
+	// 	return new TestData(test_name,
+	// 						"assertion",
+	// 						 parseInt(match[1]),
+	// 						 parseInt(match[2]),
+	// 						 parseInt(match[3]), o);
 
-
-
-	if (quantified_assertion_regex.test(o)) {
-		const match = o.match(quantified_assertion_regex);
-
-		if (match == null) {
-			return undefined;
-		}
-
-		let testName = match[4] + "_quantified_assertion_for_" + match[5] + "_" + match[6];
-		return new TestData(testName,
-							"quantified_assertion",
-							 parseInt(match[1]),
-							 parseInt(match[2]),
-							 parseInt(match[3]), o);
-
-		// Entire string is match[0]
-		// Line number is match[1]
-		// Column number is match[2]
-		// Span is match[3]
-		// Direction of assertion is match[4]
-		// Predicate name is match[5]
-		// Temp name is match[6]
-
-	} else if (assertion_regex.test(o)) {
-		const match = o.match(assertion_regex);
-		if (match == null) {
-			return undefined;
-		}
-
-
-		// Entire string is match[0]
-		// Line number is match[1]
-		// Column number is match[2]
-		// Span is match[3]
-		// Direction of assertion is match[4]
-		// Predicate name is match[5]
-		// Temp name is match[6]
-
-		let test_name = match[4] + "_assertion_for_" + match[5] + "_" + match[6];
-		return new TestData(test_name,
-							"assertion",
-							 parseInt(match[1]),
-							 parseInt(match[2]),
-							 parseInt(match[3]), o);
-
-	} else if (example_regex.test(o)) {
+	// } else 
+	
+	
+	if (example_regex.test(o)) {
 		const match = o.match(example_regex);
 		if (match == null) {
 			return undefined;
@@ -154,36 +151,19 @@ export function getFailingTestData(o: string): TestData {
 		
 		let test_name = match[1];
 		return new TestData(test_name,
-							"example",
 							 -1,
 							 -1,
 							 -1, o);
 	}
-	else if (consistency_assertion_regex.test(o)) {
-		const match = o.match(consistency_assertion_regex);
-		if (match == null) {
-			return undefined;
-		}
-		let test_name = match[4] + "_assertion_for_" + match[5] + "_" + match[6];
+	else if (test_with_span_regex.test(o)) {
+        const match = o.match(test_with_span_regex);
+        if (match == null) {
+            return undefined;
+        }
 
-		return new TestData(test_name,
-							"consistency_assertion",
-							 parseInt(match[1]),
-							 parseInt(match[2]),
-							 parseInt(match[3]), o);
+        let test_name = match[4] || match[5]; // Use the first non-null match
 
-	}
-	else if (satisfaction_assertion_regex.test(o)) {
-		const match = o.match(satisfaction_assertion_regex);
-		if (match == null) {
-			return undefined;
-		}
-		let test_name = match[4] + "_assertion_" + match[5];
-		return new TestData(test_name,
-							"satisfaction_assertion",
-							 parseInt(match[1]),
-							 parseInt(match[2]),
-							 parseInt(match[3]), o);
+        return new TestData(test_name, parseInt(match[1]), parseInt(match[2]), parseInt(match[3]), o);
 	}
 	else if (test_regex.test(o)) {
 		const match = o.match(test_regex);
@@ -194,7 +174,6 @@ export function getFailingTestData(o: string): TestData {
 		let test_name = (match[1]) ? match[1] : (match[2]) ? match[2] : match[3];
 
 		return new TestData(test_name,
-							"test-expect",
 							 -1,
 							 -1,
 							 -1, o);

--- a/client/src/forge-utilities.ts
+++ b/client/src/forge-utilities.ts
@@ -61,15 +61,17 @@ export function findForgeExamples(inputText) {
 }
 
 
+//// TODO: Can we fix these?
+
 /****
  * Regex for extracting failing test names, types, and/or locations
  */
 export const example_regex = 			  	/Invalid example '(\w+)'; the instance specified does not satisfy the given predicate\./;
-export const quantified_assertion_regex = 	/:(\d+):(\d+) \(span (\d+)\)\] Test quantified_(\w+)_assertion_for_(\w+)_([^\s\\]*) failed./;
-export const assertion_regex = 				/:(\d+):(\d+) \(span (\d+)\)\] Test (\w+)_assertion_for_(\w+)_([^\s\\]*) failed./;
-export const consistency_assertion_regex =  /:(\d+):(\d+) \(span (\d+)\)\] Failed test (consistent|inconsistent)_assertion_for_(\w+)_([^\s\\]*)/;
-export const satisfaction_assertion_regex = /:(\d+):(\d+) \(span (\d+)\)\] Failed test (sat|unsat|forge_error)_assertion_([^\s\\]*)/;
-export const test_regex = 					/Failed test (\w+)\.|Theorem (\w+) failed|Test (\w+) failed\./;
+const quantified_assertion_regex = 	/:(\d+):(\d+) \(span (\d+)\)\] Test quantified_(\w+)_assertion_for_(\w+)_([^\s\\]*) failed./;
+const assertion_regex = 				/:(\d+):(\d+) \(span (\d+)\)\] Test (\w+)_assertion_for_(\w+)_([^\s\\]*) failed./;
+const consistency_assertion_regex =  /:(\d+):(\d+) \(span (\d+)\)\] Failed test (consistent|inconsistent)_assertion_for_(\w+)_([^\s\\]*)/;
+const satisfaction_assertion_regex = /:(\d+):(\d+) \(span (\d+)\)\] Failed test (sat|unsat|forge_error)_assertion_([^\s\\]*)/;
+const test_regex = 					/Failed test (\w+)\.|Theorem (\w+) failed|Test (\w+) failed\./;
 
 export class TestData {
 
@@ -88,6 +90,16 @@ export function getFailingTestsData(o: string): TestData[] {
 // TODO: This needs to be RE-WRITTEN now that the test name is NOT obvious.
 // TODO: Should we abstract out getting the test NAME, type, and location?
 export function getFailingTestData(o: string): TestData {
+
+	// TODO: Rewrite.
+	// If a test HAS a name ...
+
+
+
+
+	// Else if a test is IMPLICITLY named, ...
+
+
 
 
 	if (quantified_assertion_regex.test(o)) {

--- a/client/src/forge-utilities.ts
+++ b/client/src/forge-utilities.ts
@@ -72,9 +72,8 @@ export const example_regex = 			  	/Invalid example '(\w+)'; the instance specif
 // const consistency_assertion_regex =  /:(\d+):(\d+) \(span (\d+)\)\] Failed test (consistent|inconsistent)_assertion_for_(\w+)_([^\s\\]*)/;
 // const satisfaction_assertion_regex = /:(\d+):(\d+) \(span (\d+)\)\] Failed test (sat|unsat|forge_error)_assertion_([^\s\\]*)/;
 
-
-const test_with_span_regex = /:(\d+):(\d+) \(span (\d+)\)\] (?:Failed test (\w+)|Test (\w+) failed)\./;
-const test_regex = 					/Failed test (\w+)\.|Theorem (\w+) failed|Test (\w+) failed\./;
+const test_with_span_regex = /:(\d+):(\d+) \(span (\d+)\)\] (?:Failed test ([\w-]+)|Test ([\w-]+) failed)\./;
+const test_regex = /Failed test ([\w-]+)\.|Theorem ([\w-]+) failed|Test ([\w-]+) failed\./;
 
 export class TestData {
 

--- a/client/src/hintgenerator.ts
+++ b/client/src/hintgenerator.ts
@@ -555,10 +555,6 @@ export class HintGenerator {
 		const autograderTests = await this.getAutograderTests(testFileName);
 
 
-
-
-
-
 		// Step 3. Run the mutant against the autograder tests.
 		const ag_meta = await this.runTestsAgainstModelWithTimeout(autograderTests, mutant);
 		const ag_output = ag_meta.stderr;

--- a/client/src/racketprocess.ts
+++ b/client/src/racketprocess.ts
@@ -252,9 +252,20 @@ export class RacketProcess {
 		colnum = Math.max(0, colnum);
 		span = Math.max(1, span);
 
+		// WHAT IF THERE ARE MULTIPLE LINES?
+		// Calculate the end position considering multiple lines
 		const start = new vscode.Position(linenum, colnum);
-		const end = new vscode.Position(linenum, colnum + span);
+		let end: vscode.Position;
+		// const document = vscode.window.activeTextEditor?.document;
+		// if (document) {
+		// 	const startOffset = document.offsetAt(start);
+		// 	const endOffset = startOffset + span;
+		// 	end = document.positionAt(endOffset);
+		//} else {
+			end = new vscode.Position(linenum, colnum + span);
+		//}
 		const range = new vscode.Range(start, end);
+
 
 		return { linenum, colnum, start, end, range, line, index, filename };
 	}

--- a/client/src/racketprocess.ts
+++ b/client/src/racketprocess.ts
@@ -104,11 +104,11 @@ export class RacketProcess {
 			this.racketKilledManually = manual;
             console.log(`Killing Racket process, PID: ${this.childProcess.pid}.`);
             const platform = os.platform();
-
+			const oldPid = this.childProcess.pid;
             if (platform === 'win32') {
                 // Use taskkill on Windows
                 try {
-                    execSync(`taskkill /PID ${this.childProcess.pid} /T /F`, { stdio: 'inherit' });
+                    execSync(`taskkill /PID ${oldPid} /T /F`, { stdio: 'inherit' });
                     console.log('Racket process killed successfully on Windows');
 					this.userFacingOutput.appendLine('Racket process killed successfully on Windows');
                 } catch (error) {
@@ -118,15 +118,20 @@ export class RacketProcess {
             } else {
                 // Use SIGTERM on Unix-like systems
                 try {
+					
                     this.childProcess.kill('SIGTERM');
                     console.log('Sent SIGTERM to Racket process, waiting for it to terminate...');
 					
                     // Wait for a few seconds and then forcefully kill if still running
                     setTimeout(() => {
-                        if (this.childProcess && !this.childProcess.killed) {
+						console.log(`SIGKILL: Old PID: ${oldPid}), new PID ${this.childProcess.pid}`);
+						
+						// Kill the process with a specific pid
+                        if (this.childProcess && !this.childProcess.killed ) {
                             console.log('Racket process did not terminate, sending SIGKILL...');
                             this.childProcess.kill('SIGKILL');
                         }
+						
                     }, 5000); // Wait for 5 seconds before sending SIGKILL
                 } catch (error) {
                     console.error(`Failed to kill Racket process:`, error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
 	"name": "forge-language-server",
-	"version": "3.2.1",
+	"version": "3.4.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "forge-language-server",
-			"version": "3.2.1",
+			"version": "3.4.1",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@firebase/auth": "^0.21.0",
 				"execa": "^9.5.2",
 				"firebase": "^9.15.0",
 				"firebase-admin": "^11.4.1",
-				"forge-toadus-parser": "^1.2.0",
+				"forge-toadus-parser": "^1.2.2",
 				"glob": "^8.1.0",
 				"tcp-port-used": "^1.0.2",
 				"ts-node": "^10.9.2",
@@ -2984,9 +2984,9 @@
 			"dev": true
 		},
 		"node_modules/forge-toadus-parser": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/forge-toadus-parser/-/forge-toadus-parser-1.2.0.tgz",
-			"integrity": "sha512-twknz+vTjgcwO1auMXx3xRVIwTiJoGUyGjotisumbQ0l4KW/ilCvTPNvRTAFtnCqvJesUIVzoGAW766+VwQL2Q==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/forge-toadus-parser/-/forge-toadus-parser-1.2.2.tgz",
+			"integrity": "sha512-/mPNTjz35EkG8EB1fgEdJtqsZ43xE5Y6gSPJZn+Lvlcr3iCeeZutCL1Bx/kFNXbFKC1kSH4Mh2kgi3JYHlhMTg==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^16.9.1",
@@ -8520,9 +8520,9 @@
 			"dev": true
 		},
 		"forge-toadus-parser": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/forge-toadus-parser/-/forge-toadus-parser-1.2.0.tgz",
-			"integrity": "sha512-twknz+vTjgcwO1auMXx3xRVIwTiJoGUyGjotisumbQ0l4KW/ilCvTPNvRTAFtnCqvJesUIVzoGAW766+VwQL2Q==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/forge-toadus-parser/-/forge-toadus-parser-1.2.2.tgz",
+			"integrity": "sha512-/mPNTjz35EkG8EB1fgEdJtqsZ43xE5Y6gSPJZn+Lvlcr3iCeeZutCL1Bx/kFNXbFKC1kSH4Mh2kgi3JYHlhMTg==",
 			"requires": {
 				"@types/node": "^16.9.1",
 				"antlr4ts": "^0.5.0-alpha.3"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"description": "Forge Language Server",
 	"author": "Siddhartha Prasad",
 	"license": "",
-	"version": "3.4.1",
+	"version": "3.4.3",
 	"repository": {
 		"type": "git",
 		"url": ""
@@ -235,7 +235,7 @@
 		"execa": "^9.5.2",
 		"firebase": "^9.15.0",
 		"firebase-admin": "^11.4.1",
-		"forge-toadus-parser": "^1.2.0",
+		"forge-toadus-parser": "^1.2.2",
 		"glob": "^8.1.0",
 		"tcp-port-used": "^1.0.2",
 		"ts-node": "^10.9.2",


### PR DESCRIPTION
- Support for named assertions in Forge
- This means that we can decouple from several failure patterns, and assertions now have general test names (perhaps less than ideal for other reasons).
- Enables better reporting of skipped / failed tests