### PR TITLE
[Hotfix] Temporal Forge Toadus

### DIFF
--- a/client/src/conceptualmutator.ts
+++ b/client/src/conceptualmutator.ts
@@ -9,7 +9,7 @@ import {
 	ConsistencyAssertionTest, Expr,
 	Formula
 } from "forge-toadus-parser";
-import G from 'glob';
+import {removeForgeComments} from "./forge-utilities";
 
 
 const negationRegex = /(not|!)\s*(\b\w+\b)/;
@@ -155,7 +155,31 @@ function get_text_from_syntaxnode(b: SyntaxNode, text: string): string {
 	return get_text_block(fromRow, toRow, fromColumn, toColumn, text);
 }
 
+function getForgeLangLevel(text: string): string {
+	const defaultLangLevel = "forge";
+	let langLevel = defaultLangLevel;
 
+
+	// TODO: First remove ALL comments.
+	let toSearch = removeForgeComments(text);
+
+	// Now find the first line that has a #lang directive.
+
+	const lines = toSearch.split("\n");
+	for (const line of lines) {
+		if (line.includes("#lang")) {
+			langLevel = line.trim();
+			break;
+		}
+	}
+
+	// And remove #lang from the langLevel.
+	langLevel = langLevel.replace("#lang", "").trim();
+
+
+
+	return langLevel;
+}
 
 /*
 	Mutates a Forge ``wheat'' (aka correct solution)
@@ -170,6 +194,9 @@ export class ConceptualMutator {
 	wheat_util: ForgeUtil;
 	student_util: ForgeUtil;
 	full_source_util: ForgeUtil;
+
+
+	private targetLangLevel = "forge";
 
 	mutant: HydratedPredicate[] = [];
 
@@ -190,6 +217,12 @@ export class ConceptualMutator {
 		public test_file_name: string,
 		public source_text: string,
 		public max_mutations: number = 200) {
+
+
+		// Check the target language level in the wheat
+		this.targetLangLevel = getForgeLangLevel(this.wheat);
+
+
 
 		this.wheat_util = new ForgeUtil(wheat);
 		//this.student_util = new ForgeUtil(student_tests);
@@ -489,7 +522,10 @@ export class ConceptualMutator {
 			return `pred ${p.name}${declParams}\n {\n ${body} \n}`;
 		});
 
-		const PREFIX = "#lang forge\n option run_sterling off\n";
+
+		// THIS IS A BUG!!! (COULD BE #lang forge\temporal OR #lang forge )
+
+		const PREFIX = `#lang ${this.targetLangLevel}\n option run_sterling off\n`;
 		const sigDecls = this.hydrateSigs();
 		const sigs = sigDecls.join("\n\n");
 

--- a/client/src/conceptualmutator.ts
+++ b/client/src/conceptualmutator.ts
@@ -651,10 +651,14 @@ export class ConceptualMutator {
 		return false;
 	}
 
+	private getRandomAlphabet(): string {
+		const alphabet = "abcdefghijklmnopqrstuvwxyz";
+		return alphabet[Math.floor(Math.random() * alphabet.length)];
+	}
 
 	private getNewName(name: string) {
-
-		return `${name}_inner_${this.num_mutations}`;
+		// Just to ward off any potential name clashes.
+		return `${name}_inner_${this.num_mutations}_${this.getRandomAlphabet()}`;
 	}
 
 	///////// OPERATORS THAT EASE OR CONSTRAINT PREDICATES BY AN EXPRESSION ////////////////
@@ -677,7 +681,7 @@ export class ConceptualMutator {
 
 	protected constrainPredicateByInclusion(i: string, e: string, quantified_prefix = "", pred_args = ""): void {
 		const p_i: HydratedPredicate = this.mutant.find((p) => p.name == i);
-				this.num_mutations++;
+
 		if (!p_i) {
 			throw new Error(`Predicate ${i} not found! Something went wrong, please contact the instructor.`);
 		}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"description": "Forge Language Server",
 	"author": "Siddhartha Prasad",
 	"license": "",
-	"version": "3.5.2",
+	"version": "3.6.0",
 	"repository": {
 		"type": "git",
 		"url": ""


### PR DESCRIPTION
Hotfix: Toadus should mutate #lang forge specs to their source language.

The one exception is `forge/bsl` or `froglet`, where mutations may need to run in full Forge.